### PR TITLE
Pointing the links at the correct models

### DIFF
--- a/SIPS/sip-24.md
+++ b/SIPS/sip-24.md
@@ -35,7 +35,7 @@ Perpetual weekly inflation serves as a mechanism to keep the protocol stable for
 <!--The technical specification should describe the syntax and semantics of any new feature.-->
 Adjust [SupplySchedule.sol](https://github.com/Synthetixio/synthetix/blob/master/contracts/SupplySchedule.sol) to account for the following changes:
 - Starting on September 7, 2023, the weekly issuance of SNX tokens will adjust to 2.5% on an annualized basis.
-- This [model](https://docs.google.com/spreadsheets/d/1rVXFnZSMvHEv5XpA5Q23x-cXEo7w-2T80wlAfT-YbuI/edit#gid=1640166717) will stay in place until it is stopped or adjusted.
+- This [final model](https://docs.google.com/spreadsheets/d/1a5r9aFP5bh6wGG4-HIW2MWPf4yMthZvesZOurnG-v_8/edit#gid=0), which is based on the [origional proposed model](https://docs.google.com/spreadsheets/d/1rVXFnZSMvHEv5XpA5Q23x-cXEo7w-2T80wlAfT-YbuI/edit#gid=1445735519), will stay in place until it is stopped or adjusted.
 
 With Inflation Smoothing and 2.5% annual Terminal Inflation:
 ![image](https://user-images.githubusercontent.com/55753617/69513159-b38a8000-0efb-11ea-894e-2a89064a0998.png)


### PR DESCRIPTION
Wanted to reference the final model that the team built with a reference back to the original.