### PR TITLE
SIP-44 update: allow settlement even when exchanging is suspended

### DIFF
--- a/SIPS/sip-44.md
+++ b/SIPS/sip-44.md
@@ -39,7 +39,7 @@ The following areas can be suspended:
 
 1. **System**: All synth and SNX transfers disabled. All exchange, issue, burn, claim, loan and mint functionality disabled. This is both for system upgrades and under possible emergency situations.
 2. **Issuance**: All sUSD issuance, burning and claiming disabled, along with any loan actions.
-3. **Exchange**: All synth exchanges and settlement.
+3. **Exchange**: All synth exchanges.
 4. **Synth**: For the synth in question, all transfers of, settlement of, and exchanges into or out of disabled.
 
 Access to the above controls will be restricted to an `accessControlList`, a whitelist of addresses that for each section above, can `suspend` and/or `resume`. This whitelist will be managed by the `owner`.


### PR DESCRIPTION
From https://github.com/Synthetixio/synthetix/pull/585, this allows the system to suspend exchanges prior to upgrading `ExchangeRates`, settle all exchanges, then suspend the entire system for an update.

