### PR TITLE
fix links on README and browsable sips

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,43 @@
 # SIPs [![Discord](https://img.shields.io/discord/413890591840272394.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discordapp.com/channels/413890591840272394/) [![Twitter Follow](https://img.shields.io/twitter/follow/synthetix_io.svg?label=synthetix_io&style=social)](https://twitter.com/synthetix_io)
+
 Synthetix Improvement Proposals (SIPs) describe standards for the Synthetix platform, including core protocol specifications, client APIs, and contract standards.
 
 WIP: A browsable version of all current and draft SIPs can be found on [the official SIP site](https://sips.synthetix.io/).
 
 # Contributing
 
- 1. Review [SIP-1](SIPS/sip-1.md).
- 2. Fork the repository by clicking "Fork" in the top right.
- 3. Add your SIP to your fork of the repository. There is a [template SIP here](sip-X.md).
- 4. Submit a Pull Request to Synthetix's [SIPs repository](https://github.com/synthetixio/SIPs).
+1.  Review [SIP-1](sips/sip-1.md).
+2.  Fork the repository by clicking "Fork" in the top right.
+3.  Add your SIP to your fork of the repository. There is a [template SIP here](sip-x.md).
+4.  Submit a Pull Request to Synthetix's [SIPs repository](https://github.com/synthetixio/SIPs).
 
 Your first PR should be a first draft of the final SIP. It must meet the formatting criteria enforced by the build (largely, correct metadata in the header). An editor will manually review the first PR for a new SIP and assign it a number before merging it. Make sure you include a `discussions-to` header with the URL to a new thread on [research.synthetix.io](https://research.synthetix.io) where people can discuss the SIP as a whole.
 
 If your SIP requires images, the image files should be included in a subdirectory of the `assets` folder for that SIP as follow: `assets/sip-X` (for sip **X**). When linking to an image in the SIP, use relative links such as `../assets/sip-X/image.png`.
 
-When you believe your SIP is mature and ready to progress past the WIP phase, you should ask to have your issue added to the next governance call where it can be discussed for inclusion in a future platform upgrade. If the community agrees to include it, the SIP editors will update the state of your SIP to 'Approved'. 
+When you believe your SIP is mature and ready to progress past the WIP phase, you should ask to have your issue added to the next governance call where it can be discussed for inclusion in a future platform upgrade. If the community agrees to include it, the SIP editors will update the state of your SIP to 'Approved'.
 
-There is a 500 sUSD bounty for proposing a SIP that reaches the 'Implemented' phase. 
+There is a 500 sUSD bounty for proposing a SIP that reaches the 'Implemented' phase.
 
 # SIP Statuses
 
-* **WIP** - a SIP that is still being developed.
-* **Proposed** - a SIP that is ready to be reviewed in a governance call.
-* **Approved** - a SIP that has been accepted for implementation by the Synthetix community.
-* **Implemented** - a SIP that has been released to mainnet.
-* **Rejected** - a SIP that has been rejected.
-
+- **WIP** - a SIP that is still being developed.
+- **Proposed** - a SIP that is ready to be reviewed in a governance call.
+- **Approved** - a SIP that has been accepted for implementation by the Synthetix community.
+- **Implemented** - a SIP that has been released to mainnet.
+- **Rejected** - a SIP that has been rejected.
 
 # Validation
 
-SIPs must pass some validation tests.  The SIP repository ensures this by running tests using [html-proofer](https://rubygems.org/gems/html-proofer) and [sip_validator](https://rubygems.org/gems/sip_validator).
+SIPs must pass some validation tests. The SIP repository ensures this by running tests using [html-proofer](https://rubygems.org/gems/html-proofer) and [sip_validator](https://rubygems.org/gems/sip_validator).
 
 It is possible to run the SIP validator locally:
+
 ```
 gem install sip_validator
 sip_validator <INPUT_FILES>
 ```
 
-
 # Automerger
 
-The SIP repository contains an "auto merge" feature to ease the workload for SIP editors.  If a change is made via a PR to a draft SIP, then the authors of the SIP can Github approve the change to have it auto-merged by the [sip-automerger](https://github.com/bakaoh/sip_automerger) bot.
+The SIP repository contains an "auto merge" feature to ease the workload for SIP editors. If a change is made via a PR to a draft SIP, then the authors of the SIP can Github approve the change to have it auto-merged by the [sip-automerger](https://github.com/bakaoh/sip_automerger) bot.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ title: Synthetix Improvement Proposals
       src="https://camo.githubusercontent.com/294a3116521e16f9164255dd2d386b24767e2610/68747470733a2f2f696d672e736869656c64732e696f2f646973636f72642f3431333839303539313834303237323339342e7376673f636f6c6f723d373638414434266c6162656c3d646973636f7264266c6f676f3d6874747073253341253246253246646973636f72646170702e636f6d25324661737365747325324638633937303162393861643433373262353866313366643966363566393636652e737667"
       alt="Discord"
       data-canonical-src="https://img.shields.io/discord/413890591840272394.svg?color=768AD4&amp;label=discord&amp;logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg"
-      style="max-width:100%;"
+      style="max-width: 100%"
   /></a>
   <!-- <a href="/last-call.xml"><img src="https://img.shields.io/badge/rss-Last Calls-red.svg" alt="RSS"></a> -->
 </h1>
@@ -22,11 +22,11 @@ title: Synthetix Improvement Proposals
 
 <h2>Contributing</h2>
 <ol>
-  <li>Review <a href="SIPS/sip-1">SIP-1</a>.</li>
+  <li>Review <a href="https://sips.synthetix.io/sips/sip-1">SIP-1</a>.</li>
   <li>Fork the repository by clicking "Fork" in the top right.</li>
   <li>
     Add your SIP to your fork of the repository. There is a
-    <a href="https://github.com/Synthetixio/SIPs/blob/master/sip-X.md"
+    <a href="https://github.com/Synthetixio/SIPs/blob/master/sip-x.md"
       >template SIP here</a
     >.
   </li>


### PR DESCRIPTION
Original links on the browsable SIP page and README were linking to 404 pages making it difficult to find the required templates and SIP-1.