### PR TITLE
Create Reduce the target Collateralisation Ratio for SNX stakers to 500%

### DIFF
--- a/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
+++ b/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
@@ -1,10 +1,8 @@
-sccp: 58
-title: Reducethe target Collaterliasation Ratio for SNX stakers to 500%
-author: Akin Sawyerr (@nottrunner)
-discussions-to: https://research.synthetix.io/
+58: Reducethe target Collaterliasation Ratio for SNX stakers to 500%
+Author Akin Sawyerr (@nottrunner)
+discussions-To  https://research.synthetix.io/t/sccp-58-reduce-target-collateralisation-ratio-to-500/225
 status: Proposed
 created: 2020-11-09
-
 Simple Summary
 Decrease the target Collateralisation Ratio for SNX stakers to 500%
 

--- a/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
+++ b/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
@@ -1,3 +1,10 @@
+sccp: 58
+title: Reducethe target Collaterliasation Ratio for SNX stakers to 500%
+author: Akin Sawyerr (@nottrunner)
+discussions-to: https://research.synthetix.io/
+status: Proposed
+created: 2020-11-09
+
 Simple Summary
 Decrease the target Collateralisation Ratio for SNX stakers to 500%
 

--- a/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
+++ b/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
@@ -1,0 +1,25 @@
+Simple Summary
+Decrease the target Collateralisation Ratio for SNX stakers to 500%
+
+Abstract
+The system is much more stable with the first successful set of liquidations executing without a hitch. Its a good time to further lower c-rations to increase the opportunity to mint more debt and increase returns for synth holders and traders
+
+Motivation
+Liquidation process in place and working
+
+Network and Active c-ratio are a very health 783% and 635% respectfully, even with recent drop in SNX price
+
+Increased liquidity will support increased use of the exchange(s) and transaction fees
+
+Capital Efficiency
+
+Increased demand for synths will drive more integrations with other DeFi platforms
+
+It will allow us to further collect data on stability of the peg, would be market absorb the increased supply?
+
+We now have liquidations
+
+Copyright
+Copyright and related rights waived via CC0.
+
+Author : akinsawyerr 1

--- a/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
+++ b/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
@@ -1,34 +1,32 @@
-58: Reduce the target Collaterliasation Ratio for SNX stakers to 500%
-Author Akin Sawyerr
-discussions-To  https://research.synthetix.io/t/sccp-58-reduce-target-collateralisation-ratio-to-500/225
-status: Proposed
-created: 2020-11-09
+---
+sccp: TBA
+title: Reduce the target Collaterliasation Ratio for SNX stakers to 500%
+author: Akin Sawyerr (@Akin)
+status: TBA
+discussions-to: https://research.synthetix.io/t/sccp-58-reduce-target-collateralisation-ratio-to-500/225
+created: 2020-11-11
 
-Simple Summary
+---
+
+## Simple Summary
+
 Decrease the target Collateralisation Ratio for SNX stakers to 500%
 
-Abstract
+## Abstract
+
+<!--A short (~200 word) description of the variable change proposed.-->
+
 The system is much more stable with the first successful set of liquidations executing without a hitch. Its a good time to further lower c-rations to increase the opportunity to mint more debt and increase returns for synth holders and traders
 
-Motivation
-Liquidation process in place and working
-Network and Active c-ratio are a very health 783% and 635% respectfully, even with recent drop in SNX price
-Increased liquidity will support increased use of the exchange(s) and transaction fees
-Capital Efficiency
-Increased demand for synths will drive more integrations with other DeFi platforms
-It will allow us to further collect data on stability of the peg, would be market absorb the increased supply?
-We now have liquidations
+## Motivation
 
-Specification
-Overview 
+- Liquidation process in place and working
+- Network and Active c-ratio are a very health 783% and 635% respectfully, even with recent drop in SNX price
+- Increased liquidity will support increased use of the exchange(s) and transaction fees
+- Capital Efficiency
+- Increased demand for synths will drive more integrations with other DeFi platforms
 
-Rationale
 
-Technical Specification
+## Copyright
 
-Test Cases
-
-Configurable Values (Via SCCP)
-
-Copyright
-Copyright and related rights waived via CC0.
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
+++ b/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
@@ -1,8 +1,9 @@
-58: Reducethe target Collaterliasation Ratio for SNX stakers to 500%
-Author Akin Sawyerr (@nottrunner)
+58: Reduce the target Collaterliasation Ratio for SNX stakers to 500%
+Author Akin Sawyerr
 discussions-To  https://research.synthetix.io/t/sccp-58-reduce-target-collateralisation-ratio-to-500/225
 status: Proposed
 created: 2020-11-09
+
 Simple Summary
 Decrease the target Collateralisation Ratio for SNX stakers to 500%
 
@@ -11,18 +12,23 @@ The system is much more stable with the first successful set of liquidations exe
 
 Motivation
 Liquidation process in place and working
-
 Network and Active c-ratio are a very health 783% and 635% respectfully, even with recent drop in SNX price
-
 Increased liquidity will support increased use of the exchange(s) and transaction fees
-
 Capital Efficiency
-
 Increased demand for synths will drive more integrations with other DeFi platforms
-
 It will allow us to further collect data on stability of the peg, would be market absorb the increased supply?
-
 We now have liquidations
+
+Specification
+Overview 
+
+Rationale
+
+Technical Specification
+
+Test Cases
+
+Configurable Values (Via SCCP)
 
 Copyright
 Copyright and related rights waived via CC0.

--- a/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
+++ b/sccp/Reduce the target Collateralisation Ratio for SNX stakers to 500%
@@ -28,5 +28,3 @@ We now have liquidations
 
 Copyright
 Copyright and related rights waived via CC0.
-
-Author : akinsawyerr 1

--- a/sccp/sccp-59.md
+++ b/sccp/sccp-59.md
@@ -1,8 +1,8 @@
 ---
-sccp: TBA
-title: Reduce the target Collaterliasation Ratio for SNX stakers to 500%
+sccp: 59
+title: Reduce the target Collateralisation Ratio for SNX stakers to 500%
 author: Akin Sawyerr (@Akin)
-status: TBA
+status: Proposed
 discussions-to: https://research.synthetix.io/t/sccp-58-reduce-target-collateralisation-ratio-to-500/225
 created: 2020-11-11
 
@@ -16,16 +16,15 @@ Decrease the target Collateralisation Ratio for SNX stakers to 500%
 
 <!--A short (~200 word) description of the variable change proposed.-->
 
-The system is much more stable with the first successful set of liquidations executing without a hitch. Its a good time to further lower c-rations to increase the opportunity to mint more debt and increase returns for synth holders and traders
+The system is much more stable with the first successful set of liquidations executing without a hitch. Its a good time to further lower C-Ratios to increase the opportunity to mint more debt and increase returns for synth holders and traders
 
 ## Motivation
 
 - Liquidation process in place and working
-- Network and Active c-ratio are a very health 783% and 635% respectfully, even with recent drop in SNX price
+- Network and Active C-Ratio are a very health 783% and 635% respectfully, even with recent drop in SNX price
 - Increased liquidity will support increased use of the exchange(s) and transaction fees
 - Capital Efficiency
-- Increased demand for synths will drive more integrations with other DeFi platforms
-
+- Increased demand for Synths will drive more integrations with other DeFi platforms
 
 ## Copyright
 


### PR DESCRIPTION
---
sccp: TBA
title: Reduce the target Collaterliasation Ratio for SNX stakers to 500%
author: Akin Sawyerr (@Akin)
status: TBA
discussions-to: https://research.synthetix.io/t/sccp-58-reduce-target-collateralisation-ratio-to-500/225
created: 2020-11-11

---

## Simple Summary

Decrease the target Collateralisation Ratio for SNX stakers to 500%

## Abstract

<!--A short (~200 word) description of the variable change proposed.-->

The system is much more stable with the first successful set of liquidations executing without a hitch. Its a good time to further lower c-rations to increase the opportunity to mint more debt and increase returns for synth holders and traders

## Motivation

- Liquidation process in place and working
- Network and Active c-ratio are a very health 783% and 635% respectfully, even with recent drop in SNX price
- Increased liquidity will support increased use of the exchange(s) and transaction fees
- Capital Efficiency
- Increased demand for synths will drive more integrations with other DeFi platforms


## Copyright

Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

