### PR TITLE
SIP-109 Synth Exchange Suspension Support

### DIFF
--- a/sips/sip-109.md
+++ b/sips/sip-109.md
@@ -1,0 +1,109 @@
+---
+sip: 109
+title: Add Synth Exchange Suspension Support
+status: Proposed
+author: Justin J Moses (@justinjmoses)
+discussions-to: https://research.synthetix.io/t/tbc
+
+created: 2021-02-02
+requires (*optional):
+---
+
+<!--You can leave these HTML comments in your merged SIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new SIPs. Note that an SIP number will be assigned by an editor. When opening a pull request to submit your SIP, please use an abbreviated title in the filename, `sip-draft_title_abbrev.md`. The title should be 44 characters or less.-->
+
+## Simple Summary
+
+<!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->
+
+Add support for the restriction of specific synth exchanges during market closures without impacting their transfer.
+
+## Abstract
+
+<!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the SIP is implemented, not *why* it should be done or *how* it will be done. If the SIP proposes deploying a new contract, write, "we propose to deploy a new contract that will do x".-->
+
+The current `SystemStatus` contract (introduced in [SIP-44](https://sips.synthetix.io/sips/sip-44)) should be amended to support a new type of suspension - synth exchanges. These must be less restrictive than the synth suspensions that currently exist and only prevent exchanging to and from the specified synth, but still allow their transfer.
+
+## Motivation
+
+<!--This is the problem statement. This is the *why* of the SIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the SIP proposes changing how something is calculated, you must address *why* the current calculation is innaccurate or wrong. This is not the place to describe how the SIP will address the issue!-->
+
+The `SystemStatus` contract supports the `synthSuspension(bytes32)` method allowing the protocolDAO to suspend a synth, thereby preventing its exchange, settlement or transfer. This has been used as a fairly blunt instrument to implement daily market closures of the equity synths `sFTSE` and `sNIKKEI`. However, given the need to support [forex and commodity market closures](https://www.investopedia.com/terms/forex/f/forex-market-trading-hours.asp) as well over the weekend, and the fact that some of these synths, including `sEUR` are part of distributed pools such as the [Curve sEUR pool](https://www.curve.fi/eurs/), prohibiting transfers is too restrictive. Thus a new mechanism to merely prevent the exchange of these synths during market closures is required.
+
+## Specification
+
+<!--The specification should describe the syntax and semantics of any new feature, there are five sections
+1. Overview
+2. Rationale
+3. Technical Specification
+4. Test Cases
+5. Configurable Values
+-->
+
+### Overview
+
+<!--This is a high level overview of *how* the SIP will solve the problem. The overview should clearly describe how the new feature will be implemented.-->
+
+Add a new suspension type: `SynthExchange` to `SystemStatus`, and support the suspension and resumption of these, along with the current `Synth` suspension, in groups, thereby reducing the number of transactions required to suspend a class of synths simulatenously (say all forex or commodity synths).
+
+### Rationale
+
+<!--This is where you explain the reasoning behind how you propose to solve the problem. Why did you propose to implement the change in this way, what were the considerations and trade-offs. The rationale fleshes out what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+The `SystemStatus` contract is where all suspension is currently managed and is already integrated with exchanging, using it to create another check is the most logical and non-intrusive spot.
+
+### Technical Specification
+
+<!--The technical specification should outline the public API of the changes proposed. That is, changes to any of the interfaces Synthetix currently exposes or the creations of new ones.-->
+
+Add the following functions to `SystemStatus`:
+
+```solidity
+    bytes32 public constant SECTION_SYNTH_EXCHANGE = "SynthExchange";
+
+    function suspendSynthExchange(bytes32 currencyKey, uint256 reason) external;
+
+
+    function resumeSynthExchange(bytes32 currencyKey) external;
+```
+
+In addition, add the following helper functions to prevent the number of individual transactions required when working with a collection of synths:
+
+```solidity
+    function suspendSynthsExchange(bytes32[] calldata currencyKey, uint256 reason) external;
+
+    function resumeSynthsExchange(bytes32[] calldata currencyKey) external;
+
+    // helper function for existing suspendSynth() function
+    function suspendSynths(bytes32[] calldata currencyKeys, uint256 reason) external;
+
+    // helper function for existing resumeSynth() function
+    function resumeSynths(bytes32[] calldata currencyKeys) external;
+```
+
+During exchanges, on top of the existing checks, if either synth is suspended for exchanging, then the exchange will revert.
+
+### Test Cases
+
+<!--Test cases for an implementation are mandatory for SIPs but can be included with the implementation..-->
+
+- Given a user has some synth A and wants to exchange into synth B
+  - Given the protocolDAO has suspended the exchanging of synth B
+    - When the user attempts to exchange A into B
+      - ❌ Then the transaction reverts due to synth suspension
+    - When the user attempts transfer their synth B
+      - ✅ Then it succeeds as transfers are not impacted by synth exchange suspension
+    - When the user attempts to settle their exchanges into synth B
+      - ✅ Then it succeeds as settlement is not impacted by synth exchange suspension
+  - Given the protocolDAO has suspended the exchanging of synth A
+    - When the user attempts to exchange A into B
+      - ❌ Then the transaction reverts due to synth suspension
+
+### Configurable Values (Via SCCP)
+
+<!--Please list all values configurable via SCCP under this implementation.-->
+
+N/A
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Add support for the restriction of specific synth exchanges during market closures without impacting their transfer.
