### PR TITLE
SIP-127: update text to mirror deployment

### DIFF
--- a/sips/sip-127.md
+++ b/sips/sip-127.md
@@ -33,14 +33,14 @@ Initially, only VirtualSynths are proposed to be deployed in this way as they re
 The `ExchangerWithVirtual` contract will be modified to:
 
 1. Deploy an ERC-1167 proxy pointing to an "base" Virtual Synth contract instead of a full Virtual Synth contract.
-2. Receive the address of the base Virtual Synth contract through the `AddressResolver`.
+2. Resolve the address of the base Virtual Synth contract through the `AddressResolver`.
 
-To allow such deployments, the `VirtualSynth` contract will require changes:
+To allow such deployments, the deployed "base" `VirtualSynth` contract will require changes:
 
-1. Migrate the current `constructor` to an `initialize` function, as proxies do not run constructors
-1. A new constructor that "disables" the base contract from being initialized. This step is not strictly necessary, but preferable to avoid possible future confusion.
+1. Migrate the current `constructor` to an `initialize` function, as proxies do not run constructors.
+1. A new constructor that "disables" the contract from being initialized. This step is not strictly necessary, but preferable to avoid possible future confusion.
 
-A vanity address or universal deployer will be used to deploy the base contract to let it occupy the same (immutable) address on each desired chain. It will be made internally available to other contracts through the `AddressResolver`, as `VirtualSynthBase`.
+This base contract will be deployed through the normal deployment process, being registered in the `AddressResolver` as `VirtualSynthMastercopy`.
 
 ### Rationale
 


### PR DESCRIPTION
Small post-approved/deployment update for posterity.

Notably:

- `VirtualSynthMastercopy` was deployed through the normal deployment process rather than using a universal deployer
-  Its `AddressResolver` key was updated to `VirtualSynthMastercopy`