### PR TITLE
SIP-120: migrate to Uniswap V3 oracles

### DIFF
--- a/sips/sip-120.md
+++ b/sips/sip-120.md
@@ -34,18 +34,17 @@ To facilitate atomic exchanges, the `Synthetix` and `Exchanger` contracts will e
 1. Not having a fee reclamation window and therefore not minting any virtual synths
 1. Restrictions on source and destination synths, configurable by SCCPs
 
-Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the execution price for atomic exchanges is selected between the prices given by Chainlink oracles and Keep3r’s Uniswap and Sushiswap TWAP oracles. Three distinct prices are considered, `P_CLBUF`, `P_TWAP`, and `P_SPOT`, with the selected execution price being the one that outputs the minimum amount of destination synths:
+Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the execution price for atomic exchanges is selected between the prices given by Chainlink oracles and Uniswap V3 pools. Two distinct prices are considered, `P_CLBUF` and `P_TWAP`, with the selected execution price being the one that outputs the minimum amount of destination synths:
 
 - `P_CLBUF`: current Chainlink price, with a buffer of *N* bps applied against the trading direction (specified per-synth)
-- `P_TWAP`: minimum TWAP price between Uniswap and Sushiswap, over a window of *N* 30min periods
-- `P_SPOT`: minimum spot price between Uniswap and Sushiswap
+- `P_TWAP`: current Uniswap V3 TWAP price, over a window of *N* seconds
 
-`P_CLBUF` can be calculated internally within the current Synthetix system and `P_TWAP` and `P_SPOT` will be provided externally via [`Keep3rV4OracleUSD` (`0x471588ffe76c39815051f264d994cb45653cfd04`)](http://etherscan.io/address/0x471588ffe76c39815051f264d994cb45653cfd04#code).
+`P_CLBUF` can be calculated internally within the current Synthetix system and `P_TWAP` will be provided externally via [`UniswapV3CrossPoolOracle` (`0xeAAFD7547B781C60c71F0854a7dA2c1FF23a7dd0`)](https://etherscan.io/address/0xeaafd7547b781c60c71f0854a7da2c1ff23a7dd0#code).
 
 Finally, several new configuration settings are proposed:
 
 - `SystemSettings.maxAtomicVolumePerBlock` (`MAX_VOLUME`): the max volume for atomic exchanges accepted in a block, specified in sUSD
-- `SystemSettings.atomicTwapPriceWindow` (`TWAP_WINDOW`): the time window to use for TWAP, specified in number of 30min periods
+- `SystemSettings.atomicTwapPriceWindow` (`TWAP_WINDOW`): the time window to use for TWAP, specified in number of seconds
 - `SystemSettings.atomicEquivalentForDexPricing`: a synth's equivalent on-chain asset with higher on-chain liquidity to poll TWAP prices from. Having this specified for a synth will also allow it to be used as a source synth or destination synth in atomic exchanges.
 - `SystemSettings.atomicExchangeFeeRate`: the exchange fee rate to be paid to the debt pool on each atomic exchange, specified in bps and per-synth. If not set, the normal exchange fee rate will be applied.
 - `SystemSettings.atomicPriceBuffer` (`CL_BUFFER`): the buffer to be applied against the current Chainlink price in the direction detrimental to the trade, specified in bps and per-synth
@@ -56,19 +55,18 @@ A simplified proof-of-concept of this exchange mechanism can be found at [this `
 
 The most important considerations are with the price selection method. Ideally, the chosen method will strike a balance between preventing both flashloan style price attacks and frontrunning oracle latency attacks while enabling low-slippage execution of atomic synth exchanges for high-value, cross-asset swaps across multiple equivalent-asset AMM pools (e.g. Curve).
 
-The three prices of `P_CLBUF`, `P_TWAP`, and `P_SPOT` each have their own strengths and weaknesses:
+The prices of `P_CLBUF` and `P_TWAP` have their own strengths and weaknesses:
 
 - `P_CLBUF`: `P_CL`, the current Chainlink price, is the official “internal” price used for all other exchanges and system debt calculations. However, its update latency is easily gamed via technical frontrunning in today’s circumstances. `P_CLBUF` provides a buffer of *N* bps (`CL_BUFFER`) from `P_CL` to provide a safety net from the deviation threshold for Chainlink oracle updates. Note that `CL_BUFFER` is configurable per-synth and `P_CLBUF` is calculated using the larger `CL_BUFFER` of the source and destination synth.
-- `P_TWAP`: Uniswap and Sushiswap TWAPs are designed to only update at the next block, preventing flashloan style attacks and making longer-term manipulation costly to the attacker. However, by their construction, TWAPs always lag behind spot.
-- `P_SPOT`: Spot prices derived from Uniswap and Sushiswap generally follow spot, but are easy to manipulate via a flashloan or sandwich attack.
+- `P_TWAP`: Uniswap V3 TWAPs are designed to only update based on the state at the beginning of the block, preventing flashloan style attacks and making longer-term manipulation costly to the attacker. However, by their construction, TWAPs always lag behind spot.
 
-By selecting the worst price amongst these three at any given time, the hope is that a “good enough but not exploitable” price can be obtained for the vast majority of situations. In the remainder, there may be periods of high volatility where one price dramatically lags behind, whereby traders will likely forgo atomic execution to obtain a better price through the fee reclamation route.
+By selecting the worst price between these two at any given time, the hope is that a “good enough but not exploitable” price can be obtained for the vast majority of situations. In the remainder, there may be periods of high volatility where one price dramatically lags behind, whereby traders will likely forgo atomic execution to obtain a better price through the fee reclamation route.
 
 To show that the price selection method of choosing the price that gives the minimum output is safe, we note various potential market and exploit situations:
 
 - If any price provides better output than `P_CL`, a trader can immediately arbitrage back through a fee reclamation exchange
-- If `P_CL` is about to be updated, traders will, at best, receive an output that is dampened by the `CL_BUFFER` rate. This essentially provides the same defense as fee reclamation, but taken in advance on a fixed rate.
-- If `P_TWAP` or `P_SPOT` are used, a synth trader could be impacted by a set of sandwich transactions on Uniswap or Sushiswap that negatively impacts their exchange price. However, such attacks only grief the synth trader, not the debt pool, and come at a cost of at least 60bps (30bps per swap) for the attacker.
+- If `P_CL` is about to be updated, traders will, at best, receive an output that is dampened by the `CL_BUFFER` rate. This essentially provides the same defense as fee reclamation, but taken in advance at a fixed rate.
+- If `P_TWAP` is used, a synth trader's execution price could be negatively impacted by a price manipulation attack across multiple blocks on Uniswap. However, such attacks only grief the synth trader, not the debt pool, and come at large risk for the griefer due to the need to hold a position across multiple blocks and a lack of atomic execution (i.e. no Flashbots). This scenario would also be similar to a griefer risking capital in one or more CEXes to briefly grief participants by changing `P_CL`, but even costlier to run due to the TWAP period.
 - On-chain prices usually follow CEX, so a trader could “frontrun the on-chain market” at the expense of the debt pool in periods of clear market directionality. However, it could be argued that this also applies with fee reclamation, only that it requires more careful timing.
 
 The final concern was backtested with front-running strategies over a few periods of clear market directionality, showing that traders were likely to obtain positive results--at the expense of the debt pool--in such conditions if no price dampeners were included. Adding exchange fees into the model effectively hindered most strategies from taking profit, although it was observed that the necessary rates would be different between BTC and ETH, which prompted for per-synth configuration of the `CL_BUFFER` and exchange fee rates.
@@ -93,7 +91,7 @@ In detail, `Exchanger.exchangeAtomically()` will:
 
 1. Use the `onlySynthetixorSynth` modifier and other user-input related sanity checks
 1. Settle any previous fee reclamation exchanges on the source synth
-1. Select the execution price between `P_CLBUF`, `P_TWAP`, and `P_SPOT` via `ExchangeRates.effectiveAtomicValueAndRates()`
+1. Select the execution price between `P_CLBUF` and `P_TWAP` via `ExchangeRates.effectiveAtomicValueAndRates()`
 1. Sanity check the current exchange's Chainlink rates against the internal circuit breaker ([SIP-65](https://sips.synthetix.io/sips/sip-65)) as well as the obtained atomic rate against the current Chainlink rate
 1. Ensure both the source synth and destination synth can be atomically exchanged and that one of them is sUSD
 1. Update the volume counter, `Exchanger.lastAtomicVolume`, for the current exchange’s sUSD value and check that the per-block volume limit for atomic exchanges is not exceeded
@@ -109,21 +107,12 @@ Note that internal system updates arising from the exchange, e.g. updating the d
 `ExchangeRates.effectiveAtomicValueAndRates()` selects the execution price by:
 
 1. Applying `CL_BUFFER` to `P_CL` to obtain `P_CLBUF`
-1. Querying the [`Keep3rV4OracleUSD` oracle aggregation contract (`0x471588ffe76c39815051f264d994cb45653cfd04`)](http://etherscan.io/address/0x471588ffe76c39815051f264d994cb45653cfd04#code) to obtain `P_AGG`, the minimum output between `P_TWAP` (based on `TWAP_WINDOW`), `P_SPOT`, and `P_CL`
-1. Finally, outputting whichever of `P_CLBUF` and `P_AGG` provides the minimum output
+1. Querying the [`UniswapV3CrossPoolOracle` contract (`0xeAAFD7547B781C60c71F0854a7dA2c1FF23a7dd0`)](https://etherscan.io/address/0xeaafd7547b781c60c71f0854a7da2c1ff23a7dd0) to obtain `P_TWAP`
+1. Outputting whichever of `P_CLBUF` and `P_TWAP` provides the minimum output
 
-For step 2, note that due to the low liquidity of synths on Uniswap and Sushiswap, queries to `Keep3rV4OracleUSD` require synths to be mapped to an equivalent non-synth version with high liquidity instead. This can be configured via SCCPs by calling `SystemSettings.setAtomicEquivalentForDexPricing()`.
+For step 2, note that due to the low liquidity of synths on Uniswap, queries to `UniswapV3CrossPoolOracle` require synths to be mapped to an equivalent non-synth version with high liquidity instead. This can be configured via SCCPs by calling `SystemSettings.setAtomicEquivalentForDexPricing()`.
 
-In the event `Keep3rV4OracleUSD` needs to be replaced, the owner of `ExchangeRates` will have the ability to update its address.
-
-Finally, while outside of the Synthetix system, it may be worthwhile to note the technical characteristics of the `Keep3rV4OracleUSD` and its underlying Keep3r TWAP oracle contracts:
-
-- `Keep3rV4OracleUSD` aggregates the [Uniswap (`0x73353801921417F465377c8d898c6f4C0270282C`)](http://etherscan.io/address/0x73353801921417F465377c8d898c6f4C0270282C#code) and [Sushiswap (`0xf67Ab1c914deE06Ba0F264031885Ea7B276a7cDa`)](http://etherscan.io/address/0xf67Ab1c914deE06Ba0F264031885Ea7B276a7cDa#code) Keep3r TWAP oracles, providing the minimum output from each source’s TWAP and spot, and the current Chainlink price
-- `Keep3rV4OracleUSD` uses ETH as the routing mechanism between assets, such that a query not involving ETH requires two hops. For example, USDC:BTC is the combination of two separate observations for USDC:ETH and ETH:BTC.
-- Each Keep3r TWAP oracle maintains its own whitelist of query-able assets, generally limited to a few high-liquidity pools which may be expanded through governance
-- Each Keep3r TWAP oracle is incentivized by the Keep3r network to be “data fresh” to the last 30min
-- In cases of “data staleness”, either due to network congestion or incentive failures, queries may result in reverts. Reverts are ensured if the last observation saved is outside the desired window (“immediately stale”), but further observations in the past are allowed to be stale if multiple periods are specified.
-- All quoted prices are returned in the output asset's decimals (which may not be 18, e.g. USDC, USDT, WBTC)
+In the event `UniswapV3CrossPoolOracle` needs to be replaced, for example to use a more complicated oracle that aggregates multiple DEXes, the owner of `ExchangeRates` will have the ability to do so.
 
 ### Test Cases
 
@@ -137,34 +126,30 @@ The cases below assume no trading fees or rebates are applied. Other configurati
 
 On a sUSD -> sETH trade of 1000 sUSD (prices reported in sUSD:sETH):
 
-- Given `P_TWAP` of 0.01, `P_SPOT` of 0.011, `P_CL` of 0.011, and `CL_BUFFER` of 50bps
+- Given `P_TWAP` of 0.01, `P_CL` of 0.011, and `CL_BUFFER` of 50bps
   - Choose 0.01 (`P_TWAP`) to output 10 sETH
-- Given `P_TWAP` of 0.01, `P_SPOT` of 0.0098, `P_CL` of 0.0099, and `CL_BUFFER` of 50bps
-  - Choose 0.00098 (`P_SPOT`) to output 9.8 sETH
-- Given `P_TWAP` of 0.01, `P_SPOT` of 0.011, `P_CL` of 0.0099, and `CL_BUFFER` of 50bps
+- Given `P_TWAP` of 0.01, `P_CL` of 0.0099, and `CL_BUFFER` of 50bps
   - Choose 0.0098505 (`P_CLBUF`) to output 9.8505 sETH
-- Given `P_TWAP` of 0.01, `P_SPOT` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 50bps
+- Given `P_TWAP` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 50bps
   - Choose 0.00995 (`P_CLBUF`) to output 9.95 sETH
-- Given `P_TWAP` of 0.01, `P_SPOT` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 0bps
-  - Choose 0.01 (`P_TWAP`/`P_SPOT`/`P_CLBUF`) to output 10 sETH
+- Given `P_TWAP` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 0bps
+  - Choose 0.01 (`P_TWAP`/`P_CLBUF`) to output 10 sETH
 
 Conversely, on a sETH -> sUSD trade of 10 sETH (prices reported in sETH:sUSD):
 
-- Given `P_TWAP` of 100, `P_SPOT` of 110, `P_CL` of 110, and `CL_BUFFER` of 50bps:
+- Given `P_TWAP` of 100, `P_CL` of 110, and `CL_BUFFER` of 50bps:
   - Choose 100 (`P_TWAP`) to output 1000 sUSD
-- Given `P_TWAP` of 100, `P_SPOT` of 98, `P_CL` of 99, and `CL_BUFFER` of 50bps
-  - Choose 98 (`P_SPOT`) to output 980 sUSD
-- Given `P_TWAP` of 100, `P_SPOT` of 110, `P_CL` of 99, and `CL_BUFFER` of 50bps
+- Given `P_TWAP` of 100, `P_CL` of 99, and `CL_BUFFER` of 50bps
   - Choose 98.505 (`P_CLBUF`) to output 985.05 sUSD
-- Given `P_TWAP` of 100, `P_SPOT` of 100, `P_CL` of 100, and `CL_BUFFER` of 0bps
-  - Choose 100 (`P_TWAP`/`P_SPOT`/`P_CLBUF`) to output 1000 sUSD
+- Given `P_TWAP` of 100, `P_CL` of 100, and `CL_BUFFER` of 0bps
+  - Choose 100 (`P_TWAP`/`P_CLBUF`) to output 1000 sUSD
 
 ### Configurable Values (Via SCCP)
 
 Relevant only for atomic exchanges:
 
 - Per-block volume limit, specified in sUSD
-- TWAP time window, specified in number of 30min periods
+- TWAP time window, specified in number of seconds
 - Synth equivalents for TWAP price look ups, specified in token addresses
 - Synths allowed, specified with a synth having a mapped equivalent (above)
 - Fee override for atomic exchanges, specified in bps and per-synth
@@ -173,7 +158,7 @@ Relevant only for atomic exchanges:
 Initially, this SIP proposes the following system configuration:
 
 - `SystemSettings.maxAtomicVolumePerBlock`: TBD
-- `SystemSettings.atomicTwapPriceWindow`: 2 (i.e. 60min)
+- `SystemSettings.atomicTwapPriceWindow`: 1800 (i.e. 30min)
 - `SystemSettings.atomicEquivalentForDexPricing` (and thereby also allowing these synths to be exchanged atomically):
   - sUSD: USDC
   - sETH: WETH9

--- a/sips/sip-120.md
+++ b/sips/sip-120.md
@@ -1,6 +1,6 @@
 ---
 sip: 120
-title: Keep3r TWAP Exchange Function
+title: TWAP Exchange Function
 status: Approved
 author: Kain Warwick (@kaiynne), Andre Cronje (@andrecronje), Justin Moses (@justinjmoses), Brett Sun (@sohkai)
 discussions-to: https://research.synthetix.io/t/sip-120-keep3r-twap-exchange-function/364
@@ -10,25 +10,25 @@ created: 2021-02-24
 
 ## Simple Summary
 
-Provide a new exchange function allowing users to atomically exchange assets without fee reclamation by pricing synths via a combination of Chainlink and Keep3r TWAP oracles.
+Provide a new exchange function allowing users to atomically exchange assets without fee reclamation by pricing synths via a combination of Chainlink and DEX TWAP oracles (Uniswap V3).
 
 ## Abstract
 
-This SIP proposes a new parallel exchange function that enables atomic transactions between synths by eschewing the current fee reclamation mechanism. The price selection method is designed to be resistant against both frontrunning oracle latency and flash loan attacks by sourcing prices from Chainlink and Keep3r TWAP oracles.
+This SIP proposes a new parallel exchange function that enables atomic transactions between synths by eschewing the current fee reclamation mechanism. The price selection method is designed to be resistant against both frontrunning oracle latency and flashloan attacks by sourcing prices from Chainlink and DEX TWAP oracles (Uniswap V3).
 
 ## Motivation
 
-Fee reclamation prevents atomic transactions between synths, degrading the composability of synths in the wider DeFi ecosystem. An attempt at improving fee reclamation came with [SIP-89 (Virtual Synths)](https://sips.synthetix.io/sips/sip-89), which was designed to enable atomic transactions between synths without removing the frontrunning protection provided by fee reclamation. The intent was to enable cross asset swaps between AMM pools within protocols like Curve by tokenizing the claim to an exchange requiring fee reclamation. While virtual synths have now been enabled and have proved fairly successful, they continue to present significant UX friction for implementers and users due to a second transaction still being required to settle the exchange.
+Fee reclamation prevents atomic transactions between synths, degrading the composability of synths in the wider DeFi ecosystem. An attempt at improving fee reclamation came with [SIP-89 (Virtual Synths)](https://sips.synthetix.io/sips/sip-89), which was designed to enable atomic transactions between synths without removing the frontrunning protection provided by fee reclamation. The intent was to enable cross-asset swaps between AMM pools within protocols like Curve by tokenizing the claim to an exchange requiring fee reclamation. While virtual synths have now been enabled and have proved fairly successful, they continue to present significant UX friction for implementers and users due to a second transaction still being required to settle the exchange.
 
-On-chain TWAP price oracles were introduced with UniswapV2 and present an opportunity as an alternative source of prices for fully atomic, one transaction synth exchanges. These price oracles are difficult to technically frontrun, as you’d have to frontrun an active market, and as a result do not expose clean, “pure profit” frontrunning opportunities akin to those based on oracle latency. Furthermore, they have been carefully constructed to be resilient to manipulation from both flashloan and longer-window attacks.
+On-chain TWAP price oracles were introduced with Uniswap V2, expanded upon in Uniswap V3, and have been increasingly utilized in DeFi. For Synthetix, they present an opportunity to utilize an alternative source of prices for fully atomic, one transaction exchanges of synths. These price oracles are difficult to technically frontrun, as you’d have to frontrun an active market, and as a result do not expose clean, “pure profit” frontrunning opportunities akin to those based on oracle latency. Furthermore, they have been carefully constructed to be resilient to manipulation from both flashloan and longer-window attacks.
 
-TWAP oracles have recently seen increased usage in several DeFi projects as a lagging price oracle and, importantly, there now exists a decentralized infrastructure network that is incentivized to maintain these oracles’ price-freshness via Keep3r (e.g. see the [Uniswap](https://keep3r.network/keep3r/job/0x73353801921417F465377c8d898c6f4C0270282C) and [Sushiswap](https://keep3r.network/keep3r/job/0xf67Ab1c914deE06Ba0F264031885Ea7B276a7cDa) TWAP oracle jobs on Keep3r).
+Initially, TWAP prices will be sourced directly from Uniswap V3 pools with the expectation that the Synthetix system will only query large-liquidity markets such as WETH/WBTC and WETH/USDC. In the future, the oracle sources may be adjusted based on the assets enabled for atomic exchanges and their market conditions.
 
 ## Specification
 
 ### Overview
 
-To facilitate atomic exchanges, the `Synthetix` and `Exchanger` contracts will expose a new function, `exchangeAtomically()`. This new function will act in a similar manner to the current `Exchanger.exchange()` flow but with primary differences in:
+To facilitate atomic exchanges, the `Synthetix` and `Exchanger` contracts will expose a new function `exchangeAtomically()`. This new function will act in a similar manner to the current `Exchanger.exchange()` flow but with primary differences in:
 
 1. The execution price, detailed below
 1. Not having a fee reclamation window and therefore not minting any virtual synths
@@ -50,11 +50,11 @@ Finally, several new configuration settings are proposed:
 - `SystemSettings.atomicExchangeFeeRate`: the exchange fee rate to be paid to the debt pool on each atomic exchange, specified in bps and per-synth. If not set, the normal exchange fee rate will be applied.
 - `SystemSettings.atomicPriceBuffer` (`CL_BUFFER`): the buffer to be applied against the current Chainlink price in the direction detrimental to the trade, specified in bps and per-synth
 
-A simplified proof-of-concept of this exchange mechanism can be found with [this `SynthetixAMM` contract](https://etherscan.io/address/0x70d8cdb1f0b684286335857514b9b63c8df2090d#code).
+A simplified proof-of-concept of this exchange mechanism can be found at [this `SynthetixAMM` contract](https://etherscan.io/address/0x70d8cdb1f0b684286335857514b9b63c8df2090d#code) (sourcing from defunct Keep3r TWAP oracles).
 
 ### Rationale
 
-The most important considerations are around the price selection method. Ideally, the chosen method will strike a balance between preventing both flash loan style price attacks and frontrunning oracle latency attacks while enabling low-slippage execution of atomic synth exchanges on high value cross asset swaps across multiple curve-style AMM pools.
+The most important considerations are with the price selection method. Ideally, the chosen method will strike a balance between preventing both flashloan style price attacks and frontrunning oracle latency attacks while enabling low-slippage execution of atomic synth exchanges for high-value, cross-asset swaps across multiple equivalent-asset AMM pools (e.g. Curve).
 
 The three prices of `P_CLBUF`, `P_TWAP`, and `P_SPOT` each have their own strengths and weaknesses:
 
@@ -75,7 +75,7 @@ The final concern was backtested with front-running strategies over a few period
 
 To reduce the risk of `CL_BUFFER` not providing adequate protection in multi-hop exchanges, this SIP proposes to initially require sUSD as the source or destination synth in an atomic exchange. For example, exchanging between sETH and sBTC involves two reads from Chainlink (ETH:USD and BTC:USD), increasing the potential for oracle latency abuse when updates to both prices are expected.
 
-Finally, as further backstops to decrease the risk associated with this new exchange mechanism, the proposed configuration parameters allow the system to be gradually eased-in through increasing per-block volume limits, asset whitelisting, and pricing-related parameter tweaks.
+Finally, as further backstops to decrease the risk associated with this new exchange mechanism, the proposed configuration parameters allow the system to be gradually eased in by increasing per-block volume limits, asset whitelisting, and pricing-related parameter tweaks.
 
 ### Technical Specification
 
@@ -97,14 +97,14 @@ In detail, `Exchanger.exchangeAtomically()` will:
 1. Sanity check the current exchange's Chainlink rates against the internal circuit breaker ([SIP-65](https://sips.synthetix.io/sips/sip-65)) as well as the obtained atomic rate against the current Chainlink rate
 1. Ensure both the source synth and destination synth can be atomically exchanged and that one of them is sUSD
 1. Update the volume counter, `Exchanger.lastAtomicVolume`, for the current exchange’s sUSD value and check that the per-block volume limit for atomic exchanges is not exceeded
-1. Execute the exchange by burning source synth, issuing destination synth, and collecting fees. Crucially, this step issues destination synths directly to the exchanger and does not create new virtual synths, bypassing fee reclamation. Fees collected will be derived from the amount of destination synths issued at this step.
-1. If required, remit the fee with any required conversions back to sUSD (priced via internal Chainlink rate).
+1. Execute the exchange by burning source synth, issuing destination synth, and collecting fees. Crucially, this step issues destination synths directly to the account executing the exchange and does not create new virtual synths, bypassing fee reclamation. Fees collected will be derived from the amount of destination synths issued at this step.
+1. If required, remit the fee with any required conversions back to sUSD (priced via internal Chainlink rate) using either the default fee rate or atomic fee rate.
 1. Update internal bookkeeping with the new exchange and debt snapshot (priced via internal Chainlink rate), and emit related events
 1. Process trading rewards
 
 When diffed against the current `Exchanger.exchange()`, only steps 3 through 8 should present meaningful differences in `Exchanger.exchangeAtomically()`’s implementation.
 
-Note that internal system updates arising from the exchange, e.g. updating the debt cache or circuit breaker, will continue to use the current Chainlink rate rather than the selected execution price in 6.
+Note that internal system updates arising from the exchange, e.g. updating the debt cache or circuit breaker, will continue to use the current Chainlink rate rather than the selected execution price in 3.
 
 `ExchangeRates.effectiveAtomicValueAndRates()` selects the execution price by:
 
@@ -166,7 +166,7 @@ Relevant only for atomic exchanges:
 - Per-block volume limit, specified in sUSD
 - TWAP time window, specified in number of 30min periods
 - Synth equivalents for TWAP price look ups, specified in token addresses
-- Synths allowed, specified with a synth having an equivalent mapped (above)
+- Synths allowed, specified with a synth having a mapped equivalent (above)
 - Fee override for atomic exchanges, specified in bps and per-synth
 - Price buffer against Chainlink, specified in bps and per-synth
 
@@ -176,7 +176,7 @@ Initially, this SIP proposes the following system configuration:
 - `SystemSettings.atomicTwapPriceWindow`: 2 (i.e. 60min)
 - `SystemSettings.atomicEquivalentForDexPricing` (and thereby also allowing these synths to be exchanged atomically):
   - sUSD: USDC
-  - sETH: ETH
+  - sETH: WETH9
   - sBTC: WBTC
 - `SystemSettings.atomicExchangeFeeRate`: TBD
 - `SystemSettings.atomicPriceBuffer`: TBD

--- a/sips/sip-120.md
+++ b/sips/sip-120.md
@@ -181,6 +181,12 @@ Initially, this SIP proposes the following system configuration:
 - `SystemSettings.atomicExchangeFeeRate`: TBD
 - `SystemSettings.atomicPriceBuffer`: TBD
 
+## Historical context
+
+SIP-120 was initially proposed with Keep3r's TWAP oracles, whose liveliness and correctness relied on an external network of incentivized actors to provide rates of whitelisted assets from Uniswap V2 and Sushiswap liquidity pools.
+
+However, near the end of this SIP's initial development, Uniswap V3 was revealed and, important to this SIP, included expanded oracle functionality that allowed one to retrieve TWAP rates directly from a Uniswap V3 pool. This was a critical improvement that allows the Synthetix system to both save gas and minimize external dependencies by not relying on an external network of actors to maintain a TWAP oracle.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/sips/sip-120.md
+++ b/sips/sip-120.md
@@ -1,7 +1,7 @@
 ---
 sip: 120
 title: TWAP Exchange Function
-status: Approved
+status: Proposed
 author: Kain Warwick (@kaiynne), Andre Cronje (@andrecronje), Justin Moses (@justinjmoses), Brett Sun (@sohkai)
 discussions-to: https://research.synthetix.io/t/sip-120-keep3r-twap-exchange-function/364
 

--- a/sips/sip-120.md
+++ b/sips/sip-120.md
@@ -39,7 +39,7 @@ Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the exe
 - `P_CLBUF`: current Chainlink price, with a buffer of *N* bps applied against the trading direction (specified per-synth)
 - `P_TWAP`: current Uniswap V3 TWAP price, over a window of *N* seconds
 
-`P_CLBUF` can be calculated internally within the current Synthetix system and `P_TWAP` will be provided externally via [`UniswapV3CrossPoolOracle` (`0x42253680cca5f10B4579801ad0935eE697F46E4F`)](https://etherscan.io/address/0x42253680cca5f10b4579801ad0935ee697f46e4f#readContract).
+`P_CLBUF` can be calculated internally within the current Synthetix system and `P_TWAP` will be provided externally via [`UniswapV3CrossPoolOracle` (`0x0F1f5A87f99f0918e6C81F16E59F3518698221Ff`)](https://etherscan.io/address/0x0f1f5a87f99f0918e6c81f16e59f3518698221ff#readContract).
 
 Finally, several new configuration settings are proposed:
 

--- a/sips/sip-120.md
+++ b/sips/sip-120.md
@@ -132,6 +132,10 @@ On a sUSD -> sETH trade of 1000 sUSD (prices reported in sUSD:sETH):
   - Choose 0.0098505 (`P_CLBUF`) to output 9.8505 sETH
 - Given `P_TWAP` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 50bps
   - Choose 0.00995 (`P_CLBUF`) to output 9.95 sETH
+- Given `P_TWAP` of 0.0099, `P_CL` of 0.01, and `CL_BUFFER` of 200bps
+  - Choose 0.0098 (`P_CLBUF`) to output 9.8 sETH
+- Given `P_TWAP` of 0.0099, `P_CL` of 0.01, and `CL_BUFFER` of 0bps
+  - Choose 0.0099 (`P_TWAP`) to output 9.9 sETH
 - Given `P_TWAP` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 0bps
   - Choose 0.01 (`P_TWAP`/`P_CLBUF`) to output 10 sETH
 
@@ -141,6 +145,12 @@ Conversely, on a sETH -> sUSD trade of 10 sETH (prices reported in sETH:sUSD):
   - Choose 100 (`P_TWAP`) to output 1000 sUSD
 - Given `P_TWAP` of 100, `P_CL` of 99, and `CL_BUFFER` of 50bps
   - Choose 98.505 (`P_CLBUF`) to output 985.05 sUSD
+- Given `P_TWAP` of 100, `P_CL` of 100, and `CL_BUFFER` of 50bps
+  - Choose 99.5 (`P_CLBUF`) to output 995 sUSD
+- Given `P_TWAP` of 99, `P_CL` of 100, and `CL_BUFFER` of 200bps
+  - Choose 98 (`P_CLBUF`) to output 980 sUSD
+- Given `P_TWAP` of 99, `P_CL` of 100, and `CL_BUFFER` of 0bps
+  - Choose 99 (`P_TWAP`) to output 990 sUSD
 - Given `P_TWAP` of 100, `P_CL` of 100, and `CL_BUFFER` of 0bps
   - Choose 100 (`P_TWAP`/`P_CLBUF`) to output 1000 sUSD
 

--- a/sips/sip-120.md
+++ b/sips/sip-120.md
@@ -39,7 +39,7 @@ Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the exe
 - `P_CLBUF`: current Chainlink price, with a buffer of *N* bps applied against the trading direction (specified per-synth)
 - `P_TWAP`: current Uniswap V3 TWAP price, over a window of *N* seconds
 
-`P_CLBUF` can be calculated internally within the current Synthetix system and `P_TWAP` will be provided externally via [`UniswapV3CrossPoolOracle` (`0xeAAFD7547B781C60c71F0854a7dA2c1FF23a7dd0`)](https://etherscan.io/address/0xeaafd7547b781c60c71f0854a7da2c1ff23a7dd0#code).
+`P_CLBUF` can be calculated internally within the current Synthetix system and `P_TWAP` will be provided externally via [`UniswapV3CrossPoolOracle` (`0x42253680cca5f10B4579801ad0935eE697F46E4F`)](https://etherscan.io/address/0x42253680cca5f10b4579801ad0935ee697f46e4f#readContract).
 
 Finally, several new configuration settings are proposed:
 


### PR DESCRIPTION
Updates SIP-120 to source TWAP prices directly from Uniswap V3 pools (which provide native, queryable TWAP histories) rather than Keep3rV1Oracles.

Due to the changes, moves SIP-120 back to proposed.

-----

Main technical changes are isolated in 6d7dab9.