### PR TITLE
SIP-140 Allow exchange into origin address

### DIFF
--- a/sips/sip-140.md
+++ b/sips/sip-140.md
@@ -1,0 +1,94 @@
+---
+sip: 140
+title: Allow Exchange Into Origin Address
+status: Propopsed
+author: Justin J Moses (*@justinjmoses)
+discussions-to: https://research.synthetix.io
+
+created: 2021-05-18
+---
+
+<!--You can leave these HTML comments in your merged SIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new SIPs. Note that an SIP number will be assigned by an editor. When opening a pull request to submit your SIP, please use an abbreviated title in the filename, `sip-draft_title_abbrev.md`. The title should be 44 characters or less.-->
+
+## Simple Summary
+
+<!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->
+
+Add an additional exchange function to Synthetix to support transactions initiated by a user but performed through another address.
+
+## Abstract
+
+<!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the SIP is implemented, not *why* it should be done or *how* it will be done. If the SIP proposes deploying a new contract, write, "we propose to deploy a new contract that will do x".-->
+
+Modify the Synthetix contract with an additional exchange function that accepts an additional parameter. This parameter, `destinationAddress`, allows the exchange recipient to be different from the instantiator. However, to prevent users attempting fee reclamation workarounds, the restriction is that this `destinationAddress` must be the same as `tx.origin`.
+
+## Motivation
+
+<!--This is the problem statement. This is the *why* of the SIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the SIP proposes changing how something is calculated, you must address *why* the current calculation is innaccurate or wrong. This is not the place to describe how the SIP will address the issue!-->
+
+1inch.exchange would like to use Synthetix exchanges in their router as a final step in a route. This would open up routes like `WBTC > sBTC > sUSD` for instance. Right now, this cannot be done as 1inch creates a contract to perform all legs of the route and at the end, they transfer the funds to the user. As this contract is created at the time of the trade, it doesn't work with the `exchangeOnBehalf` delegation features already inside Synthetix.
+
+Now, the reason Synthetix exchanges do not currently support a custom `destinationAddress` is that this could be an attack vector. Imagine a scenario where a user frontruns a synth into `sUSD` and uses their Binance deposit address as the destination. In this instance, Binance would lose out and the user would make risk-free profit.
+
+As such, this proposal insists that the only `destinationAddress` that is allow is `tx.origin`. This works for most cases, but would fail for any contracts that use 1inch to transact - such as multisigs like Gnosis safe. This is considered an acceptable compromise for now.
+
+> Note: Fee reclamation would exist, but since it's the final step in the route, it's up to the user to later call `Exchanger.settle` or `Synth.transferAndSettle()`
+
+## Specification
+
+<!--The specification should describe the syntax and semantics of any new feature, there are five sections
+1. Overview
+2. Rationale
+3. Technical Specification
+4. Test Cases
+5. Configurable Values
+-->
+
+### Overview
+
+<!--This is a high level overview of *how* the SIP will solve the problem. The overview should clearly describe how the new feature will be implemented.-->
+
+An additional `exchangeWithTracking` function to be added to `Synthetix` which uses `tx.origin` as the destination address of an exchange.
+
+### Rationale
+
+<!--This is where you explain the reasoning behind how you propose to solve the problem. Why did you propose to implement the change in this way, what were the considerations and trade-offs. The rationale fleshes out what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+The `Exchanger` contract already supports the `destinationAddress` parameter on it's restricted `exchange()` function, so adding another function to `Synthetix` which invokes `Exchanger` with `destinationAddress` as `tx.origin` is pretty trivial.
+
+The `exchangeWithTracking` function will be used as a base, as this SIP's functionality is primarily for aggregators like 1inch which would like it to support the volume program via the `trackingCode` parameter.
+
+### Technical Specification
+
+<!--The technical specification should outline the public API of the changes proposed. That is, changes to any of the interfaces Synthetix currently exposes or the creations of new ones.-->
+
+```solidity
+interface ISynthetix {
+    function exchangeWithTrackingForInitiator(
+        bytes32 sourceCurrencyKey,
+        uint sourceAmount,
+        bytes32 destinationCurrencyKey,
+        address originator,
+        bytes32 trackingCode
+    ) external returns (uint amountReceived);
+}
+```
+
+### Test Cases
+
+<!--Test cases for an implementation are mandatory for SIPs but can be included with the implementation..-->
+
+- Given Amy has written a contract which includes a public function that calls `Synthetix.exchangeWithTrackingForInitiator()`, When she invokes this public function to trade `sUSD` for `sETH`, Then her EOA which invoked the transaction ends up with the `sETH`, and the fee reclamation settlement applies to that same EOA.
+- Given Brian invokes a 1inch contract to trade `1 WBTC` for `sUSD` which steps through Synthetix via `Synthetix.exchangeWithTrackingForInitiator()`, Then Brian ends up with the total amount of `sUSD` from the exchange, and the fee reclamation settlement applies to Brian's account.
+
+> ⚠️⚠️⚠️ Note: This process will have unintended consequences for any contracts that use 1inch to transact - such as multisigs like Gnosis safe. This is considered an acceptable compromise for now.
+
+### Configurable Values (Via SCCP)
+
+<!--Please list all values configurable via SCCP under this implementation.-->
+
+N/A
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/sips/sip-140.md
+++ b/sips/sip-140.md
@@ -1,7 +1,7 @@
 ---
 sip: 140
 title: Allow Exchange Into Origin Address
-status: Propopsed
+status: Proposed
 author: Justin J Moses (@justinjmoses)
 discussions-to: https://research.synthetix.io
 

--- a/sips/sip-140.md
+++ b/sips/sip-140.md
@@ -20,7 +20,7 @@ Add an additional exchange function to Synthetix to support transactions initiat
 
 <!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the SIP is implemented, not *why* it should be done or *how* it will be done. If the SIP proposes deploying a new contract, write, "we propose to deploy a new contract that will do x".-->
 
-Modify the Synthetix contract with an additional exchange function that accepts an additional parameter. This parameter, `destinationAddress`, allows the exchange recipient to be different from the instantiator. However, to prevent users attempting fee reclamation workarounds, the restriction is that this `destinationAddress` must be the same as `tx.origin`.
+Modify the `Synthetix` contract with an additional exchange function that uses `tx.origin` as the `destinationAddress`, allowing the exchange (and fee reclamation) recipient to be different from the `msg.sender`.
 
 ## Motivation
 
@@ -30,7 +30,7 @@ Modify the Synthetix contract with an additional exchange function that accepts 
 
 Now, the reason Synthetix exchanges do not currently support a custom `destinationAddress` is that this could be an attack vector. Imagine a scenario where a user frontruns a synth into `sUSD` and uses their Binance deposit address as the destination. In this instance, Binance would lose out and the user would make risk-free profit.
 
-As such, this proposal insists that the only `destinationAddress` that is allow is `tx.origin`. This works for most cases, but would fail for any contracts that use 1inch to transact - such as multisigs like Gnosis safe. This is considered an acceptable compromise for now.
+As such, this proposal insists that the only `destinationAddress` that is allowed is `tx.origin`. This works for most cases, but would fail for any contracts that use 1inch to transact - such as multisigs like Gnosis safe. This is considered an acceptable compromise for now.
 
 > Note: Fee reclamation would exist, but since it's the final step in the route, it's up to the user to later call `Exchanger.settle` or `Synth.transferAndSettle()`
 
@@ -48,13 +48,13 @@ As such, this proposal insists that the only `destinationAddress` that is allow 
 
 <!--This is a high level overview of *how* the SIP will solve the problem. The overview should clearly describe how the new feature will be implemented.-->
 
-An additional `exchangeWithTracking` function to be added to `Synthetix` which uses `tx.origin` as the destination address of an exchange.
+An additional `exchangeWithTracking` function to be added to `Synthetix` which uses `tx.origin` as the `destinationAddress` of an exchange.
 
 ### Rationale
 
 <!--This is where you explain the reasoning behind how you propose to solve the problem. Why did you propose to implement the change in this way, what were the considerations and trade-offs. The rationale fleshes out what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 
-The `Exchanger` contract already supports the `destinationAddress` parameter on it's restricted `exchange()` function, so adding another function to `Synthetix` which invokes `Exchanger` with `destinationAddress` as `tx.origin` is pretty trivial.
+The `Exchanger` contract already supports the `destinationAddress` parameter on it's restricted `exchange()` function, so adding another function to `Synthetix` which invokes `Exchanger` with `destinationAddress` as `tx.origin` is fairly trivial.
 
 The `exchangeWithTracking` function will be used as a base, as this SIP's functionality is primarily for aggregators like 1inch which would like it to support the volume program via the `trackingCode` parameter.
 
@@ -81,7 +81,7 @@ interface ISynthetix {
 - Given Amy has written a contract which includes a public function that calls `Synthetix.exchangeWithTrackingForInitiator()`, When she invokes this public function to trade `sUSD` for `sETH`, Then her EOA which invoked the transaction ends up with the `sETH`, and the fee reclamation settlement applies to that same EOA.
 - Given Brian invokes a 1inch contract to trade `1 WBTC` for `sUSD` which steps through Synthetix via `Synthetix.exchangeWithTrackingForInitiator()`, Then Brian ends up with the total amount of `sUSD` from the exchange, and the fee reclamation settlement applies to Brian's account.
 
-> ⚠️⚠️⚠️ Note: This process will have unintended consequences for any contracts that use 1inch to transact - such as multisigs like Gnosis safe. This is considered an acceptable compromise for now.
+> ⚠️⚠️⚠️ Note: This new function is designed for the sole use-case of a user who initiates the contract ending up with the proceeds of the exchange. This may have unintended consequences for any contracts that use 1inch to transact - including multisigs like Gnosis safe. This is considered an acceptable limitation for now.
 
 ### Configurable Values (Via SCCP)
 

--- a/sips/sip-140.md
+++ b/sips/sip-140.md
@@ -2,7 +2,7 @@
 sip: 140
 title: Allow Exchange Into Origin Address
 status: Propopsed
-author: Justin J Moses (*@justinjmoses)
+author: Justin J Moses (@justinjmoses)
 discussions-to: https://research.synthetix.io
 
 created: 2021-05-18


### PR DESCRIPTION
Add an additional exchange function to Synthetix to support transactions initiated by a user but performed through another address.