### PR TITLE
Include the ability for rewards to be altered via an SCCP

### DIFF
--- a/sips/sip-132.md
+++ b/sips/sip-132.md
@@ -52,6 +52,8 @@ The Members would receive this breakdown of SNX rewards at the end of the month:
 - 1inch: 1000 SNX
 - Enzyme: 200 SNX
 
+The amount of SNX taken from the inflationary supply can be altered in the future at the discretion of the Spartan Council via an SCCP. 
+
 ## Eligibility 
 
 During the trial period of the Volume Program, participants were required to fill out an application form. Core Contributors reviewed these applications and determined which projects were optimal for the program. The criteria Core Contributors looked for included the ability to produce trading volume for the protocol and the condition that applicants were building a product designed for end users to generate this volume. Once formalized, the Spartan Council members would vet Volume Program applicants. 


### PR DESCRIPTION
Added a statement that specifies how the rewards could be changed in the future by the Spartan Council.

