### PR TITLE
SIP-139 Amendment: Migrating to array input support

### DIFF
--- a/sips/sip-139.md
+++ b/sips/sip-139.md
@@ -59,7 +59,7 @@ While it could be argued that the `SystemStatus.resumeSynth()` function be in ch
 interface IExchanger {
 
     // Restricted to owner
-    function resetLastExchangeRate(bytes32[] currencyKeys) external;
+    function resetLastExchangeRate(bytes32[] calldata currencyKeys) external;
 
 }
 ```

--- a/sips/sip-139.md
+++ b/sips/sip-139.md
@@ -14,19 +14,19 @@ created: 2021-05-17
 
 <!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->
 
-Add a protected function to reset the last price of an exchange for some synth.
+Add a protected function to reset the last price of an exchange for some synths.
 
 ## Abstract
 
 <!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the SIP is implemented, not *why* it should be done or *how* it will be done. If the SIP proposes deploying a new contract, write, "we propose to deploy a new contract that will do x".-->
 
-Create a function in the `Exchanger` contract that can reset the `Exchanger.lastExchangeRate(bytes32)` for some synth to the current market price. This function needs to be restricted to the `owner` as an attacker could call it if they see a large price spike and then trade into or out of that synth for profit.
+Create a function in the `Exchanger` contract that can reset the `Exchanger.lastExchangeRate(bytes32)` for the given synths to their current market price. This function needs to be restricted to the `owner` as an attacker could call it if they see a large price spike and then trade into or out of that synth for profit.
 
 ## Motivation
 
 <!--This is the problem statement. This is the *why* of the SIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the SIP proposes changing how something is calculated, you must address *why* the current calculation is innaccurate or wrong. This is not the place to describe how the SIP will address the issue!-->
 
-There is currently an issue where when a synth has been suspended due to [SIP-65](./sip-65.md) and if the new rate is legitimate (and not some fault of a faulty oracle or pricing mechanism) and remains at this new rate (rather than spiking and returning), then resuming a synth will likely result in it being suspended again next exchange - unless the price shifts significantly back towards when the last trade happened.
+There is currently an issue where when a synth has been suspended due to [SIP-65](./sip-65.md) and if the new rate is legitimate (and not some fault of a faulty oracle or pricing mechanism) and remains at this new rate (rather than spiking and returning), then resuming a synth will likely result in it being suspended again next exchange and is effectively stuck - unless the price shifts significantly back towards when the last trade happened.
 
 ## Specification
 
@@ -42,7 +42,7 @@ There is currently an issue where when a synth has been suspended due to [SIP-65
 
 <!--This is a high level overview of *how* the SIP will solve the problem. The overview should clearly describe how the new feature will be implemented.-->
 
-Add an additional function to `Exchanger` that resets the `lastExchangeRate[currencyKey]` to the latest rate from the `ExchangeRates` contract.
+Add an additional function to `Exchanger` that resets the `lastExchangeRate[currencyKey]` to the latest rate from the `ExchangeRates` contract. It may only be called by the `owner`.
 
 ### Rationale
 
@@ -58,7 +58,8 @@ While it could be argued that the `SystemStatus.resumeSynth()` function be in ch
 
 interface IExchanger {
 
-    function resetLastExchangeRate(bytes32 currencyKey) onlyOwner;
+    // Restricted to owner
+    function resetLastExchangeRate(bytes32[] currencyKeys) external;
 
 }
 ```
@@ -68,7 +69,7 @@ interface IExchanger {
 <!--Test cases for an implementation are mandatory for SIPs but can be included with the implementation..-->
 
 - When `resetLastExchangeRate` is invoked by a non-owner, then it always reverts.
-- When `resetLastExchangeRates` is invoked by an owner for `bytes32 currencyKey`, then it updates `lastExchangeRate[currencyKey]` to `ExchangeRates.rateForCurrency(currencyKey)`.
+- When `resetLastExchangeRate` is invoked by an owner for `bytes32[] currencyKeys`, then for each `currencyKey` in the array, it updates `lastExchangeRate[currencyKey]` to `ExchangeRates.rateForCurrency(currencyKey)`.
 
 ### Configurable Values (Via SCCP)
 


### PR DESCRIPTION
To reduce transaction load on the `protocolDAO`, this proposal amends SIP-139 to take an array of arguments instead.