### PR TITLE
SIP 145: debt cache event consistency

### DIFF
--- a/sips/sip-145.md
+++ b/sips/sip-145.md
@@ -1,7 +1,7 @@
 ---
 sip: 145 
 title: Debt Cache Event Consistency
-status: Proposed
+status: Draft 
 author: Anton Jurisevic (@zyzek)
 discussions-to: https://research.synthetix.io/
 

--- a/sips/sip-145.md
+++ b/sips/sip-145.md
@@ -16,14 +16,16 @@ Fixes an incorrect debt cache event value.
 
 ## Abstract
 
-[SIP 136](https://sips.synthetix.io/sips/sip-136) updated the debt cache system to properly exclude short debt from
-the system debt. However, it did not perform the same deduction from the value emitted in the `DebtCacheUpdated` event
-within `DebtCache.takeDebtSnapshot`.
+[SIP 136](https://sips.synthetix.io/sips/sip-136) updated the debt cache system to properly exclude non-SNX-backed debt
+from  the system debt. However, it did not perform the same deduction from the value emitted in the `DebtCacheUpdated`
+event  within `DebtCache.takeDebtSnapshot`.
 
 ## Motivation
-The true debt snapshot value and the emitted value are out of sync. This makes it difficult to track the true
-historical debt value from the events. In addition, as this affected only full snapshots and not partial updates,
-the emitted debt cache value time series was fluctuating wildly by a factor of 2.
+The true debt snapshot value and the emitted value are out of sync; although the true cached value is being computed
+correctly, the event emitted concurrently with this value being updated does not properly exclude non-SNX-backed debt.
+This makes it difficult to track the true historical debt value from the events.
+Additionally, as this affected only full snapshots and not partial ones, the emitted debt cache value time series was
+fluctuating wildly by a factor of 2 between adjacent `DebtCacheUpdated` events.
 
 ## Specification
 <!--The specification should describe the syntax and semantics of any new feature, there are five sections
@@ -42,11 +44,12 @@ debt accounted for by the ether wrapper, loans contracts, et cetera.
 ### Rationale
 
 This is the most direct means of fixing the problem. A speedy resolution will limit the number of incorrect
-data points pushed on chain.
+data points pushed onto the chain.
 
 ### Technical Specification
 
-Within `DebtCache.takeDebtSnapshot`, `emit DebtCacheUpdated(snxCollateralDebt)` will be replaced with `emit DebtCacheUpdated(snxCollateralDebt.floorSub(excludedDebt))`.
+Within `DebtCache.takeDebtSnapshot`, `emit DebtCacheUpdated(snxCollateralDebt)` will be replaced with
+`emit DebtCacheUpdated(snxCollateralDebt.floorSub(excludedDebt))`.
 The code is available (in the github)[https://github.com/Synthetixio/synthetix/pull/1325].
 
 ### Test Cases

--- a/sips/sip-145.md
+++ b/sips/sip-145.md
@@ -1,0 +1,61 @@
+---
+sip: 145 
+title: Debt Cache Event Consistency
+status: Proposed
+author: Anton Jurisevic (@zyzek)
+discussions-to: https://research.synthetix.io/
+
+created: 2021-06-09
+---
+
+<!--You can leave these HTML comments in your merged SIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new SIPs. Note that an SIP number will be assigned by an editor. When opening a pull request to submit your SIP, please use an abbreviated title in the filename, `sip-draft_title_abbrev.md`. The title should be 44 characters or less.-->
+
+## Simple Summary
+
+Fixes an incorrect debt cache event value.
+
+## Abstract
+
+[SIP 136](https://sips.synthetix.io/sips/sip-136) updated the debt cache system to properly exclude short debt from
+the system debt. However, it did not perform the same deduction from the value emitted in the `DebtCacheUpdated` event
+within `DebtCache.takeDebtSnapshot`.
+
+## Motivation
+The true debt snapshot value and the emitted value are out of sync. This makes it difficult to track the true
+historical debt value from the events. In addition, as this affected only full snapshots and not partial updates,
+the emitted debt cache value time series was fluctuating wildly by a factor of 2.
+
+## Specification
+<!--The specification should describe the syntax and semantics of any new feature, there are five sections
+1. Overview
+2. Rationale
+3. Technical Specification
+4. Test Cases
+5. Configurable Values
+-->
+
+### Overview
+
+The event emitted inside `DebtCache.takeDebtSnapshot` will contain a corrected value, which properly excludes
+debt accounted for by the ether wrapper, loans contracts, et cetera.
+
+### Rationale
+
+This is the most direct means of fixing the problem. A speedy resolution will limit the number of incorrect
+data points pushed on chain.
+
+### Technical Specification
+
+Within `DebtCache.takeDebtSnapshot`, `emit DebtCacheUpdated(snxCollateralDebt)` will be replaced with `emit DebtCacheUpdated(snxCollateralDebt.floorSub(excludedDebt))`.
+The code is available (in the github)[https://github.com/Synthetixio/synthetix/pull/1325].
+
+### Test Cases
+
+See the (accompanying pull request)[https://github.com/Synthetixio/synthetix/pull/1325].
+
+### Configurable Values (Via SCCP)
+
+None
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This SIP proposes to fix an incorrect data point being emitted from the debt cache when snapshots are taken. These events were not correctly excluding the non-snx backed debt from their cached value, and were therefore inconsistent with the true cached value.