### PR TITLE
SIP-166 Removing sCEX, iCEX and adding sCEFI

### DIFF
--- a/sips/sip-166.md
+++ b/sips/sip-166.md
@@ -18,7 +18,7 @@ Purge and remove the `sCEX` synth along with `iCEX` and replace them with the `s
 
 In order to support the rebalancing of `sCEX` and introduction of new non-exchange elements into `sCEFI`, the current `sCEX` token must be purged and removed in order to make way for a new `sCEFI` token using the upgraded feed from Chainlink. The `iCEX` token will also be purged and removed - it will have no short equivalent for now due to [SIP-158](./sip-158.md).
 
-## Motivation
+## Motivation & Rationale
 
 <!--This is the problem statement. This is the *why* of the SIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the SIP proposes changing how something is calculated, you must address *why* the current calculation is innaccurate or wrong. This is not the place to describe how the SIP will address the issue!-->
 
@@ -37,10 +37,6 @@ In order to support the rebalancing of `sCEX` and introduction of new non-exchan
 ### Overview
 
 The new synth will behave as other indexes with no new API or semantics.
-
-### Rationale
-
-(N/A)
 
 ### Technical Specification
 

--- a/sips/sip-166.md
+++ b/sips/sip-166.md
@@ -1,0 +1,79 @@
+---
+sip: 166
+title: Removing sCEX, iCEX and adding sCEFI
+status: Draft
+author: Justin J. Moses (@justinjmoses)
+discussions-to: https://research.synthetix.io
+
+created: 2021-07-13
+---
+
+## Simple Summary
+
+<!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->
+
+Purge and remove the `sCEX` synth along with `iCEX` and replace them with the `sCEFI` synth.
+
+## Abstract
+
+In order to support the rebalancing of `sCEX` and introduction of new non-exchange elements into `sCEFI`, the current `sCEX` token must be purged and removed in order to make way for a new `sCEFI` token using the upgraded feed from Chainlink. The `iCEX` token will also be purged and removed - it will have no short equivalent for now due to [SIP-158](./sip-158.md).
+
+## Motivation
+
+<!--This is the problem statement. This is the *why* of the SIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the SIP proposes changing how something is calculated, you must address *why* the current calculation is innaccurate or wrong. This is not the place to describe how the SIP will address the issue!-->
+
+[SCCP-124](../sccps/sccp-124.md) proposed the rebalancing of the `sCEX` index with two new centralized finance tokens - `NEXO` and `CEL` - and a rename into `sCEFI` which more correctly depicts the index. A rename in this instance is not valid due to the 150k of open interest currently held in the sCEX synth, as those holders did not buy into a `sCEFI` token. In order to correctly handle this rebalance, we either a) keep `sCEX` around and create a new `sCEFI` token or b) purge `sCEX` holders into `sUSD` and create the new `sCEFI` synth allowing them to trade into it. Due to the desire to sunset `sCEX` for `sCEFI` and the cost of running an additional decentralized oracle, this SIP proposes option b) - purging existing `sCEX` holders out to `sUSD`, removing the synth and then creating the new `sCEFI` synth and ensuring Chainlink enable the feed based on the weighting in SCCP-124.
+
+## Specification
+
+<!--The specification should describe the syntax and semantics of any new feature, there are five sections
+1. Overview
+2. Rationale
+3. Technical Specification
+4. Test Cases
+5. Configurable Values
+-->
+
+### Overview
+
+The new synth will behave as other indexes with no new API or semantics.
+
+### Rationale
+
+(N/A)
+
+### Technical Specification
+
+<!--The technical specification should outline the public API of the changes proposed. That is, changes to any of the interfaces Synthetix currently exposes or the creations of new ones.-->
+
+While there is no new API changes in the SIP, there is a proposed migration contract to perform the upgrade (this pattern was introduced in [SIP-151](./sip-151.md) allows the pDAO to easily manage a multi-step migration).
+
+Following a pre-deployment of the `sCEFI` synth, proxy and token state and the suspension of `sCEFI` for trading, the whole upgrade can be performed in a single migration contract as follows:
+
+- `SynthsCEX`, `SynthiCEX`, `ExchangeRates`, `Issuer` accept ownership
+- Purge all holders of `iCEX` (it's frozen)
+- Remove `iCEX` from `Issuer`
+- Configure `sCEX` to be frozen at its current rate (this is to avoid the 100k open interest limitation on purging a non-inverse synth)
+- Purge all holders of `sCEX`
+- Remove `sCEX` from `Issuer`
+- `ExchangeRates` add aggregator for `sCEFI` (the same feed address currently used for `sCEFI`)
+- Add `sCEFI` to `Issuer` (note it will remain suspended for trading until the Chainlink feed is rebalanced)
+- Return ownerships of all system contracts
+
+Once the migration is complete, a new version of Synthetix will be released to npm and Chainlink oracles can upgrade to the new index. Once all of the oracles have upgraded to the new index (approximately one week), the pDAO can resume `sCEFI` for trading.
+
+### Test Cases
+
+<!--Test cases for an implementation are mandatory for SIPs but can be included with the implementation..-->
+
+TBD
+
+### Configurable Values (Via SCCP)
+
+<!--Please list all values configurable via SCCP under this implementation.-->
+
+N/A
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/sips/sip-166.md
+++ b/sips/sip-166.md
@@ -1,7 +1,7 @@
 ---
 sip: 166
 title: Removing sCEX, iCEX and adding sCEFI
-status: Draft
+status: SC_Review_Pending
 author: Justin J. Moses (@justinjmoses)
 discussions-to: https://research.synthetix.io
 


### PR DESCRIPTION
In order to support the rebalancing of `sCEX` and introduction of new non-exchange elements into `sCEFI`, the current `sCEX` token must be purged and removed in order to make way for a new `sCEFI` token using the upgraded feed from Chainlink. The `iCEX` token will also be purged and removed - it will have no short equivalent for now due to [SIP-158](./sip-158.md).
