### PR TITLE
spelling and fixes to sip-160

### DIFF
--- a/sips/sip-160.md
+++ b/sips/sip-160.md
@@ -7,21 +7,26 @@ discussions-to: Discord Governance
 
 created: 2021-07-13
 requires: 130
-
 ---
 
 ## Simple Summary
-(SIP-130)[https://sips.synthetix.io/sips/sip-130] introduced a number of new states in the SIP workflow, this SIP intends to clarify some of the exceptions to this workflow to ensure there is consensus in the community about SIP meta-governance. This SIP also introduces additional meta-data headers to ensure all critical information is tracked within each SIP.
+
+[SIP-130](https://sips.synthetix.io/sips/sip-130) introduced a number of new states in the SIP workflow, this SIP intends to clarify some of the exceptions to this workflow to ensure there is consensus in the community about SIP meta-governance. This SIP also introduces additional meta-data headers to ensure all critical information is tracked within each SIP.
 
 ## Abstract
+
 <!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the SIP is implemented, not *why* it should be done or *how* it will be done. If the SIP proposes deploying a new contract, write, "we propose to deploy a new contract that will do x".-->
-This SIP is a meta-goverance SIP to addresses and clarifies the workflow for the SIPs repository specified in SIP-130, by introducing new meta-data and explicit process flows between SIP states.
+
+This SIP is a meta-governance SIP to addresses and clarifies the workflow for the SIPs repository specified in SIP-130, by introducing new meta-data and explicit process flows between SIP states.
 
 ## Motivation
+
 <!--This is the problem statement. This is the *why* of the SIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the SIP proposes changing how something is calculated, you must address *why* the current calculation is innaccurate or wrong. This is not the place to describe how the SIP will address the issue!-->
-The introduction of new SIP states in SIP-130 has created some uncertainty within the SIP editors and council. This SIP will reduce that undcertainty and more clearly describe what the the various actors in the SIP process can do.
+
+The introduction of new SIP states in SIP-130 has created some uncertainty within the SIP editors and council. This SIP will reduce that uncertainty and more clearly describe what the the various actors in the SIP process can do.
 
 ## Specification
+
 <!--The specification should describe the syntax and semantics of any new feature, there are five sections
 1. Overview
 2. Rationale
@@ -31,36 +36,47 @@ The introduction of new SIP states in SIP-130 has created some uncertainty withi
 -->
 
 ### Overview
+
 <!--This is a high level overview of *how* the SIP will solve the problem. The overview should clearly describe how the new feature will be implemented.-->
+
 The following rules will be added to the SIPs process:
 
-1. SIP editor roles can only be assigned by the Council, this is an update to what is stated in SIP-1 wich will need to be updated if this SIP passes.
+1. SIP editor roles can only be assigned by the Council, this is an update to what is stated in SIP-1 which will need to be updated if this SIP passes.
 2. The SIP editors are the only ones who can merge to the SIPs repo, this is to ensure correct processes and procedures are adhered to for SIPs and SCCPs.
 3. If a SIP author submits a PR to a SIP that is already in “Vote Pending” the SIP editor must notify the council of the change before merging the PR, and if requested move the SIP back into “Feasibility”.
 4. If a SIP author submits a PR to a SIP that is already in “Approved” or “Implemented” then the SIP editor must request a review of the change by the Council and, if the change is deemed material by the council, must move the SIP back to “Feasibility”.
 5. If a SIP is in “Approved” or “Implemented” and the CC assigned to the SIP no longer believes the SIP is feasible to implement they must notify the Council as soon as is practical that a vote should be held to decide whether to move the SIP to “Rejected”.
 6. A vote to move a SIP from “Approved” or “Implemented” to “Rejected” must reference the previous vote and the SIP should be updated with a note to indicate that it was “Rejected” for infeasibility post Approval.
-7. SIP editors must merge or close PRs to the SIPs repo within a reasonable time, ideally within two weeks of submission. The Council can request a SIP editor to expedite the process if needed to allow governance to assess the SIP.
+7. SIP editors must merge or close PRs to the SIPs repo within a reasonable time, ideally within two weeks of submission. The Council can request a SIP editor to extend this process if needed to allow governance to assess the SIP.
 8. A Council member may at any time request that a SIP be moved from “Rejected” back to “Feasibility” if they believe that the underlying circumstances that caused the SIP to be rejected have changed.
 9. SIP editors who fail to adhere to the consensus rules and procedures can be removed at the discretion of the council.
 10. A new meta-data field will be added to each SIP, "Implementor" represents the CC or CCs assigned to implement the SIP.
 11. A new meta-data field will be added to each SIP, "Release" represents the name of the release under which the SIP was deployed to mainnet.
 
 ### Rationale
+
 <!--This is where you explain the reasoning behind how you propose to solve the problem. Why did you propose to implement the change in this way, what were the considerations and trade-offs. The rationale fleshes out what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
 By explicitly describing which state transitions are allowed we constrain the power of the SIP editors to modify the SIPs repo ensuring they are merely maintaining the repo in line with community consensus and are not required to interpret what is the correct process for a SIP in a specific situation. Adding the new meta-data to the SIPs will ensure there is clarity in the community as to who is responsible for each SIP throughout the SIP workflow and into which release the SIP was deployed.
 
 ### Technical Specification
+
 <!--The technical specification should outline the public API of the changes proposed. That is, changes to any of the interfaces Synthetix currently exposes or the creations of new ones.-->
+
 N/A
 
 ### Test Cases
+
 <!--Test cases for an implementation are mandatory for SIPs but can be included with the implementation..-->
+
 N/A
 
 ### Configurable Values (Via SCCP)
+
 <!--Please list all values configurable via SCCP under this implementation.-->
+
 N/A
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Fixes some spelling errors and also I believe you mean

`L50: "The Council can request a SIP editor to extend this process" changed expedite to extend`