### PR TITLE
SIP-120: update based on latest implementation

### DIFF
--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -1,6 +1,6 @@
 ---
 sip: 120
-title: TWAP Exchange Function
+title: Atomic Exchange Function
 status: Approved
 author: Kain Warwick (@kaiynne), Andre Cronje (@andrecronje), Justin Moses (@justinjmoses), Brett Sun (@sohkai)
 discussions-to: https://research.synthetix.io/t/sip-120-keep3r-twap-exchange-function/364

--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -48,7 +48,7 @@ Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the exe
 Finally, several new configuration settings are proposed:
 
 - `SystemSettings.maxAtomicVolumePerBlock` (`MAX_VOLUME`): the max volume for atomic exchanges accepted in a block, specified in sUSD
-- `SystemSettings.atomicTwapPriceWindow` (`TWAP_WINDOW`): the time window to use for TWAP, specified in number of seconds
+- `SystemSettings.atomicTwapWindow` (`TWAP_WINDOW`): the time window to use for TWAP, specified in number of seconds
 - `SystemSettings.atomicEquivalentForDexPricing`: a synth's equivalent on-chain asset with higher on-chain liquidity to poll TWAP prices from. Having this specified for a synth will also allow it to be used as a source synth or destination synth in atomic exchanges.
 - `SystemSettings.atomicExchangeFeeRate`: the exchange fee rate to be paid to the debt pool on each atomic exchange, specified in bps and per-synth. If not set, the normal exchange fee rate will be applied.
 - `SystemSettings.atomicPriceBuffer` (`CL_BUFFER`): the buffer to be applied against the current Chainlink price in the direction detrimental to the trade, specified in bps and per-synth
@@ -86,7 +86,7 @@ Add the following interfaces and storage variables:
 - `Exchanger.exchangeAtomically()` and `Synthetix.exchangeAtomically()`
 - `ExchangeRates.effectiveAtomicValueAndRates()`
 - `Exchanger.lastAtomicVolume` (`struct { uint64 block, uint192 volume }`), `SystemSettings.maxAtomicVolumePerBlock` (`uint256`), and related setter `SystemSettings.setMaxAtomicVolumePerBlock()`, configurable by SCCPs
-- `SystemSettings.atomicTwapPriceWindow` (`uint256`) and related setter `SystemSettings.setAtomicPriceWindow()`, configurable by SCCPs
+- `SystemSettings.atomicTwapWindow` (`uint256`) and related setter `SystemSettings.setAtomicTwapWindow()`, configurable by SCCPs
 - `SystemSettings.atomicEquivalentForDexPricing` (`mapping (bytes32 => address)`) and related setter `SystemSettings.setAtomicEquivalentForDexPricing()`, configurable by SCCPs
 - `SystemSettings.atomicExchangeFeeRate` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicExchangeFeeRate()`, configurable by SCCPs
 - `SystemSettings.atomicPriceBuffer` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicPriceBuffer()`, configurable by SCCPs
@@ -172,7 +172,7 @@ Relevant only for atomic exchanges:
 Initially, this SIP proposes the following system configuration:
 
 - `SystemSettings.maxAtomicVolumePerBlock`: TBD
-- `SystemSettings.atomicTwapPriceWindow`: 1800 (i.e. 30min)
+- `SystemSettings.atomicTwapWindow`: 1800 (i.e. 30min)
 - `SystemSettings.atomicEquivalentForDexPricing` (and thereby also allowing these synths to be exchanged atomically):
   - sUSD: USDC
   - sETH: WETH9

--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -1,7 +1,7 @@
 ---
 sip: 120
 title: Atomic Exchange Function
-status: Approved
+status: SC_Review_Pending
 author: Kain Warwick (@kaiynne), Andre Cronje (@andrecronje), Justin Moses (@justinjmoses), Brett Sun (@sohkai)
 discussions-to: https://research.synthetix.io/t/sip-120-keep3r-twap-exchange-function/364
 

--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -47,7 +47,7 @@ Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the exe
 
 Finally, several new configuration settings are proposed:
 
-- `SystemSettings.maxAtomicVolumePerBlock` (`MAX_VOLUME`): the max volume for atomic exchanges accepted in a block, specified in sUSD
+- `SystemSettings.atomicMaxVolumePerBlock` (`MAX_VOLUME`): the max volume for atomic exchanges accepted in a block, specified in sUSD
 - `SystemSettings.atomicTwapWindow` (`TWAP_WINDOW`): the time window to use for TWAP, specified in number of seconds
 - `SystemSettings.atomicEquivalentForDexPricing`: a synth's equivalent on-chain asset with higher on-chain liquidity to poll TWAP prices from. Having this specified for a synth will also allow it to be used as a source synth or destination synth in atomic exchanges.
 - `SystemSettings.atomicExchangeFeeRate`: the exchange fee rate to be paid to the debt pool on each atomic exchange, specified in bps and per-synth. If not set, the normal exchange fee rate will be applied.
@@ -85,7 +85,7 @@ Add the following interfaces and storage variables:
 
 - `Exchanger.exchangeAtomically()` and `Synthetix.exchangeAtomically()`
 - `ExchangeRates.effectiveAtomicValueAndRates()`
-- `Exchanger.lastAtomicVolume` (`struct { uint64 block, uint192 volume }`), `SystemSettings.maxAtomicVolumePerBlock` (`uint256`), and related setter `SystemSettings.setMaxAtomicVolumePerBlock()`, configurable by SCCPs
+- `Exchanger.lastAtomicVolume` (`struct { uint64 time, uint192 volume }`), `SystemSettings.atomicMaxVolumePerBlock` (`uint256`), and related setter `SystemSettings.setAtomicMaxVolumePerBlock()`, configurable by SCCPs
 - `SystemSettings.atomicTwapWindow` (`uint256`) and related setter `SystemSettings.setAtomicTwapWindow()`, configurable by SCCPs
 - `SystemSettings.atomicEquivalentForDexPricing` (`mapping (bytes32 => address)`) and related setter `SystemSettings.setAtomicEquivalentForDexPricing()`, configurable by SCCPs
 - `SystemSettings.atomicExchangeFeeRate` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicExchangeFeeRate()`, configurable by SCCPs
@@ -171,7 +171,7 @@ Relevant only for atomic exchanges:
 
 Initially, this SIP proposes the following system configuration:
 
-- `SystemSettings.maxAtomicVolumePerBlock`: TBD
+- `SystemSettings.atomicMaxVolumePerBlock`: TBD
 - `SystemSettings.atomicTwapWindow`: 1800 (i.e. 30min)
 - `SystemSettings.atomicEquivalentForDexPricing` (and thereby also allowing these synths to be exchanged atomically):
   - sUSD: USDC

--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -89,6 +89,8 @@ Several new configuration settings are proposed:
 - `SystemSettings.atomicEquivalentForDexPricing`: a synth's equivalent on-chain asset with higher on-chain liquidity to poll DEX-based prices from. Having this specified for a synth will also allow it to be used as a source synth or destination synth in atomic exchanges.
 - `SystemSettings.atomicExchangeFeeRate`: the exchange fee rate to be paid to the debt pool on each atomic exchange, specified in bps and per-synth. If not set, the regular exchange fee rate will be applied.
 - `SystemSettings.atomicPriceBuffer` (`CL_BUFFER`): the buffer to be applied against the current Chainlink price in the direction detrimental to the trade, specified in bps and per-synth
+- `SystemSettings.atomicVolatilityConsiderationWindow`: the time window to evaluate whether a synth is too volatile to atomically exchange, specified in number of seconds
+- `SystemSettings.atomicVolatilityUpdateThreshold`: the maximum number of Chainlink updates in the consideration window before a synth is deemed too volatile to atomically exchange, specified in number of updates
 
 ### Rationale
 
@@ -101,7 +103,7 @@ The prices of `P_CLBUF` and `P_DEX` have their own strengths and weaknesses:
   - `P_DEX_TWAP`: Uniswap V3 TWAPs are designed to only update based on the state at the beginning of the block, preventing flashloan style attacks and making longer-term manipulation costly to the attacker. However, by their construction, TWAPs always lag behind spot.
   - `P_DEX_SPOT`: Uniswap V3 spot prices generally follow CEX spot but can be easy to manipulate via flashloan or sandwich style attacks when used improperly. The proposed `IDexPriceAggregator`'s implementation sources spot from the prior block's observed price rather than the current block's, mitigating intra-block flashloan and sandwich style attacks. However, this measurement is still subject to short-term volatility, such as a large trade occurring in the prior block.
 
-By selecting the worst price between `P_CLBUF`, `P_DEX_TWAP`, and `P_DEX_SPOT` at any given time, the hope is that a “good enough but not exploitable” price can be obtained for the vast majority of situations. In the remainder, there may be periods of high volatility where one price dramatically lags behind, whereby traders will likely forgo atomic execution to obtain a better price through the fee reclamation route.
+By selecting the worst price between `P_CLBUF`, `P_DEX_TWAP`, and `P_DEX_SPOT` at any given time, the hope is that a “good enough but not exploitable” price can be obtained for the vast majority of situations. In the remainder, there may be periods of high volatility where one price dramatically lags behind, whereby traders will likely forgo atomic execution to obtain a better price through the fee reclamation route--or be prevented from atomic exchanges altogether via the volatility circuit breaker detailed below.
 
 To show that the price selection method of choosing the price that gives the minimum output is safe, we note various potential market and exploit situations:
 
@@ -111,6 +113,8 @@ To show that the price selection method of choosing the price that gives the min
 - On-chain prices usually follow CEX, so a trader could “frontrun the on-chain market” at the expense of the debt pool in periods of clear market directionality. However, it could be argued that this also applies with fee reclamation, only that it requires more careful timing.
 
 The final concern was backtested with front-running strategies over a few periods of clear market directionality, showing that traders were likely to obtain positive results--at the expense of the debt pool--in such conditions if no price dampeners were included. Adding exchange fees into the model effectively hindered most strategies from taking profit, although it was observed that the necessary rates would be different between BTC and ETH, which prompted for per-synth configuration of the `CL_BUFFER` and exchange fee rates.
+
+To further decrease the risk to the debt pool during periods of clear market directionality, a volatility circuit breaker is included to automatically disable and re-enable atomic exchanges for a given synth based on its perceived volatility. This circuit breaker uses the number of Chainlink updates over the past _N_ seconds as a proxy for volatility; if there are more updates than the configured threshold, the synth is deemed too volatile.
 
 To reduce the risk of `CL_BUFFER` not providing adequate protection in multi-hop exchanges, this SIP proposes to initially require sUSD as the source or destination synth in an atomic exchange. For example, exchanging between sETH and sBTC involves two reads from Chainlink (ETH:USD and BTC:USD), increasing the potential for oracle latency abuse when updates to both prices are expected.
 
@@ -129,6 +133,8 @@ Then, add the following interfaces and storage variables:
 - `SystemSettings.atomicEquivalentForDexPricing` (`mapping (bytes32 => address)`) and related setter `SystemSettings.setAtomicEquivalentForDexPricing()`, configurable by SCCPs
 - `SystemSettings.atomicExchangeFeeRate` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicExchangeFeeRate()`, configurable by SCCPs
 - `SystemSettings.atomicPriceBuffer` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicPriceBuffer()`, configurable by SCCPs
+- `SystemSettings.atomicVolatilityConsiderationWindow` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicVolatilityConsiderationWindow()`, configurable by SCCPs
+- `SystemSettings.atomicVolatilityUpdateThreshold` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicVolatilityUpdateThreshold()`, configurable by SCCPs
 
 In detail, `ExchangerWithFeeReclamationAlternatives.exchangeAtomically()` will:
 
@@ -210,6 +216,7 @@ Relevant only for atomic exchanges:
 - Synths allowed, specified with a synth having a mapped equivalent (above)
 - Fee override for atomic exchanges, specified in bps and per-synth
 - Price buffer against Chainlink, specified in bps and per-synth
+- Volatility threshold based on Chainlink updates, specified in number of updates over a number of seconds and per-synth
 
 Initially, this SIP proposes the following system configuration:
 
@@ -221,6 +228,8 @@ Initially, this SIP proposes the following system configuration:
   - sBTC: WBTC
 - `SystemSettings.atomicExchangeFeeRate`: TBD
 - `SystemSettings.atomicPriceBuffer`: TBD
+- `SystemSettings.atomicVolatilityConsiderationWindow`: TBD
+- `SystemSettings.atomicVolatilityUpdateThreshold`: TBD
 
 ## Historical context
 

--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -14,63 +14,100 @@ Justin Moses (@justinjmoses), Brett Sun (@sohkai)
 
 ## Simple Summary
 
-Provide a new exchange function allowing users to atomically exchange assets without fee reclamation by pricing synths via a combination of Chainlink and DEX TWAP oracles (Uniswap V3).
+Provide a new exchange function allowing users to atomically exchange assets without fee reclamation by pricing synths via a combination of Chainlink and DEX oracles (Uniswap V3). This functionality will only be available on Ethereum's base layer (L1).
 
 ## Abstract
 
-This SIP proposes a new parallel exchange function that enables atomic transactions between synths by eschewing the current fee reclamation mechanism. The price selection method is designed to be resistant against both frontrunning oracle latency and flashloan attacks by sourcing prices from Chainlink and DEX TWAP oracles (Uniswap V3).
+This SIP proposes a new exchange function for L1 that enables atomic transactions between synths by eschewing the current fee reclamation mechanism. The price selection method is designed to be resistant against both frontrunning oracle latency and flashloan attacks by sourcing prices from Chainlink and DEX oracles.
 
 ## Motivation
 
 Fee reclamation prevents atomic transactions between synths, degrading the composability of synths in the wider DeFi ecosystem. An attempt at improving fee reclamation came with [SIP-89 (Virtual Synths)](https://sips.synthetix.io/sips/sip-89), which was designed to enable atomic transactions between synths without removing the frontrunning protection provided by fee reclamation. The intent was to enable cross-asset swaps between AMM pools within protocols like Curve by tokenizing the claim to an exchange requiring fee reclamation. While virtual synths have now been enabled and have proved fairly successful, they continue to present significant UX friction for implementers and users due to a second transaction still being required to settle the exchange.
 
-On-chain TWAP price oracles were introduced with Uniswap V2, expanded upon in Uniswap V3, and have been increasingly utilized in DeFi. For Synthetix, they present an opportunity to utilize an alternative source of prices for fully atomic, one transaction exchanges of synths. These price oracles are difficult to technically frontrun, as you’d have to frontrun an active market, and as a result do not expose clean, “pure profit” frontrunning opportunities akin to those based on oracle latency. Furthermore, they have been carefully constructed to be resilient to manipulation from both flashloan and longer-window attacks.
+DEX-based oracles have come a long way in DeFi, with on-chain TWAP oracles introduced in Uniswap V2, expanded upon in Uniswap V3, and seen increasing adoption by DeFi protocols. For Synthetix, they present an opportunity to utilize an alternative source of prices for fully atomic, one transaction exchanges of synths. Used correctly, these TWAP oracles are difficult to technically frontrun, as one would have to frontrun an active market, and thereby do not expose clean, “pure profit” frontrunning opportunities akin to those based on oracle latency. Furthermore, these TWAP oracles have been carefully constructed to be resilient to manipulation from both flashloan and longer-window attacks.
 
-Initially, TWAP prices will be sourced directly from Uniswap V3 pools with the expectation that the Synthetix system will only query large-liquidity markets such as WETH/WBTC and WETH/USDC. In the future, the oracle sources may be adjusted based on the assets enabled for atomic exchanges and their market conditions.
+Initially, the Synthetix system will source DEX-based pricing from Uniswap V3 with the expectation that only large-liquidity markets such as WETH/WBTC and WETH/USDC will be queried. The reported DEX-based price of a synth will be an aggregation of Uniswap V3's latest price, "spot", and a TWAP based on a configurable window, and then compared against the current Chainlink rate. In the future, the DEX-based price may be re-configured to include other sources or pricing models based on the assets enabled for atomic exchanging and evolving market conditions.
+
+The proposed functionality in this SIP is intended only for L1. The current reality, and ongoing hope, of the L2 Synthetix system is to mitigate oracle latency frontrunning, and thereby avoid non-atomic transactions altogether (i.e. no fee reclamation), with the much faster transaction processing capabilities of L2.
 
 ## Specification
 
 ### Overview
 
-To facilitate atomic exchanges, the `Synthetix` and `Exchanger` contracts will expose a new function `exchangeAtomically()`. This new function will act in a similar manner to the current `Exchanger.exchange()` flow but with primary differences in:
+Taken altogether, this SIP introduces three major changes to the current system:
+
+1. A refactoring of the `Exchanger` and `ExchangeRates` contracts, splitting each into a shared base class and environment-specific (L1) variant
+1. A new `exchangeAtomically()` function, implementing atomic exchanges
+1. A new `IDexPriceAggregator` concept, to plug in DEX-based pricing of synths
+
+And additionally, a number of new configurable values in `SystemSettings`.
+
+#### Environment-specific `Exchanger` and `ExchangeRates`
+
+L1-specific functionality in `Exchanger` and `ExchangeRates` will be spun out into `ExchangerWithFeeReclamationAlternatives` and `ExchangeRatesWithDexPricing`, respectively. `ExchangerWithFeeReclamationAlternatives` will amalgamate and replace the current `ExchangerWithVirtualSynth` variant of `Exchanger`.
+
+On L1, these variants will be deployed instead of the base `Exchanger` and `ExchangeRates` contracts. To the system (via `AddressResolver`), these variants will still be known as `Exchanger` and `ExchangeRates`.
+
+#### `exchangeAtomically()`
+
+To facilitate atomic exchanges, the `Synthetix` and `ExchangerWithFeeReclamationAlternatives` contracts will expose a new function `exchangeAtomically()`. This new function will act in a similar manner to the current `Exchanger.exchange()` flow but with primary differences in:
 
 1. The execution price, detailed below
 1. Not having a fee reclamation window and therefore not minting any virtual synths
 1. Restrictions on source and destination synths, configurable by SCCPs
 
-Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the execution price for atomic exchanges is selected between the prices given by Chainlink oracles and Uniswap V3 pools. Two distinct prices are considered, `P_CLBUF` and `P_DEX`, with the selected execution price being the one that outputs the minimum amount of destination synths:
+Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the execution price for atomic exchanges is selected between the prices given by Chainlink oracles and DEX-based oracles. Two distinct prices are considered, `P_CLBUF` and `P_DEX`, with the selected execution price being the one that outputs the minimum amount of destination synths:
 
 - `P_CLBUF`: current Chainlink price, with a buffer of _N_ bps applied against the trading direction (specified per-synth)
-- `P_DEX`: current Uniswap V3 TWAP price, over a window of _N_ seconds
+- `P_DEX`: aggregated DEX price, over a window of _N_ seconds (if a TWAP is considered)
 
-`P_CLBUF` can be calculated internally within the current Synthetix system and `P_DEX` will be provided externally via [`UniswapV3CrossPoolOracle` (`0x0F1f5A87f99f0918e6C81F16E59F3518698221Ff`)](https://etherscan.io/address/0x0f1f5a87f99f0918e6c81f16e59f3518698221ff#readContract).
+`P_CLBUF` can be calculated internally within the current Synthetix system. `P_DEX` is provided externally from an oracle contract implementing `IDexPriceAggregator`.
 
-Finally, several new configuration settings are proposed:
+#### `IDexPriceAggregator`
 
-- `SystemSettings.atomicMaxVolumePerBlock` (`MAX_VOLUME`): the max volume for atomic exchanges accepted in a block, specified in sUSD
-- `SystemSettings.atomicTwapWindow` (`TWAP_WINDOW`): the time window to use for TWAP, specified in number of seconds
-- `SystemSettings.atomicEquivalentForDexPricing`: a synth's equivalent on-chain asset with higher on-chain liquidity to poll TWAP prices from. Having this specified for a synth will also allow it to be used as a source synth or destination synth in atomic exchanges.
-- `SystemSettings.atomicExchangeFeeRate`: the exchange fee rate to be paid to the debt pool on each atomic exchange, specified in bps and per-synth. If not set, the normal exchange fee rate will be applied.
+To source DEX-based prices, a new `IDexPriceAggregator` interface is introduced. Its interface consists of a single pricing function, `assetToAsset()`:
+
+```solidity
+function assetToAsset(
+    address tokenIn,
+    uint amountIn,
+    address tokenOut,
+    uint twapPeriod
+) external view returns (uint amountOut);
+```
+
+The external oracle contract implementing `IDexPriceAggregator` can source prices from any DEX and use any internal measure to aggregate multiple pricing methods. A complex example of an `IDexPriceAggregator` oracle contract would source prices from Uniswap V3 and Sushiswap, and aggregate their spot and TWAP prices together via a liquidity-weighted mean.
+
+Initially, this SIP proposes to use an `IDexPriceAggregator` that sources prices solely from Uniswap V3, returning the worst price between the "spot" and TWAP. This initial oracle has been deployed to [`0x` (`DexPriceAggregatorUniswapV3`)](https://etherscan.io/address/0x#readContract).
+
+#### `SystemSettings`
+
+Several new configuration settings are proposed:
+
+- `SystemSettings.atomicMaxVolumePerBlock`: the max volume for atomic exchanges accepted in a block, specified in sUSD
+- `SystemSettings.atomicTwapWindow`: the time window to consider for a DEX-based TWAP, specified in number of seconds
+- `SystemSettings.atomicEquivalentForDexPricing`: a synth's equivalent on-chain asset with higher on-chain liquidity to poll DEX-based prices from. Having this specified for a synth will also allow it to be used as a source synth or destination synth in atomic exchanges.
+- `SystemSettings.atomicExchangeFeeRate`: the exchange fee rate to be paid to the debt pool on each atomic exchange, specified in bps and per-synth. If not set, the regular exchange fee rate will be applied.
 - `SystemSettings.atomicPriceBuffer` (`CL_BUFFER`): the buffer to be applied against the current Chainlink price in the direction detrimental to the trade, specified in bps and per-synth
-
-A simplified proof-of-concept of this exchange mechanism can be found at [this `SynthetixAMM` contract](https://etherscan.io/address/0x70d8cdb1f0b684286335857514b9b63c8df2090d#code) (sourcing from defunct Keep3r TWAP oracles).
 
 ### Rationale
 
-The most important considerations are with the price selection method. Ideally, the chosen method will strike a balance between preventing both flashloan style price attacks and frontrunning oracle latency attacks while enabling low-slippage execution of atomic synth exchanges for high-value, cross-asset swaps across multiple equivalent-asset AMM pools (e.g. Curve).
+The most important considerations concern the price selection method. Ideally, the chosen method will strike a balance between preventing both flashloan style price attacks and frontrunning oracle latency attacks while enabling low-slippage execution of atomic exchanges for high-value, cross-asset swaps involving synths across multiple equivalent-asset AMM pools (e.g. Curve).
 
 The prices of `P_CLBUF` and `P_DEX` have their own strengths and weaknesses:
 
-- `P_CLBUF`: `P_CL`, the current Chainlink price, is the official “internal” price used for all other exchanges and system debt calculations. However, its update latency is easily gamed via technical frontrunning in today’s circumstances. `P_CLBUF` provides a buffer of _N_ bps (`CL_BUFFER`) from `P_CL` to provide a safety net from the deviation threshold for Chainlink oracle updates. Note that `CL_BUFFER` is configurable per-synth and `P_CLBUF` is calculated using the larger `CL_BUFFER` of the source and destination synth.
-- `P_DEX`: Uniswap V3 TWAPs are designed to only update based on the state at the beginning of the block, preventing flashloan style attacks and making longer-term manipulation costly to the attacker. However, by their construction, TWAPs always lag behind spot.
+- `P_CLBUF`: `P_CL`, the current Chainlink price, is the official “internal” price used for all other exchanges and system debt calculations. However, its update latency is easily gamed via technical frontrunning on L1. `P_CLBUF` provides a buffer of _N_ bps (`CL_BUFFER`) from `P_CL` to provide a safety net from the deviation threshold for Chainlink oracle updates. `CL_BUFFER` is configurable per-synth and `P_CLBUF` is calculated using the larger `CL_BUFFER` of the source and destination synth.
+- `P_DEX`: `P_DEX` is the worst price between two separate pricing methods from Uniswap V3:
+  - `P_DEX_TWAP`: Uniswap V3 TWAPs are designed to only update based on the state at the beginning of the block, preventing flashloan style attacks and making longer-term manipulation costly to the attacker. However, by their construction, TWAPs always lag behind spot.
+  - `P_DEX_SPOT`: Uniswap V3 spot prices generally follow CEX spot but can be easy to manipulate via flashloan or sandwich style attacks when used improperly. The proposed `IDexPriceAggregator`'s implementation sources spot from the prior block's observed price rather than the current block's, mitigating intra-block flashloan and sandwich style attacks. However, this measurement is still subject to short-term volatility, such as a large trade occurring in the prior block.
 
-By selecting the worst price between these two at any given time, the hope is that a “good enough but not exploitable” price can be obtained for the vast majority of situations. In the remainder, there may be periods of high volatility where one price dramatically lags behind, whereby traders will likely forgo atomic execution to obtain a better price through the fee reclamation route.
+By selecting the worst price between `P_CLBUF`, `P_DEX_TWAP`, and `P_DEX_SPOT` at any given time, the hope is that a “good enough but not exploitable” price can be obtained for the vast majority of situations. In the remainder, there may be periods of high volatility where one price dramatically lags behind, whereby traders will likely forgo atomic execution to obtain a better price through the fee reclamation route.
 
 To show that the price selection method of choosing the price that gives the minimum output is safe, we note various potential market and exploit situations:
 
 - If any price provides better output than `P_CL`, a trader can immediately arbitrage back through a fee reclamation exchange
-- If `P_CL` is about to be updated, traders will, at best, receive an output that is dampened by the `CL_BUFFER` rate. This essentially provides the same defense as fee reclamation, but taken in advance at a fixed rate.
-- If `P_DEX` is used, a synth trader's execution price could be negatively impacted by a price manipulation attack across multiple blocks on Uniswap. However, such attacks only grief the synth trader, not the debt pool, and come at large risk for the griefer due to the need to hold a position across multiple blocks and a lack of atomic execution (i.e. no Flashbots). This scenario would also be similar to a griefer risking capital in one or more CEXes to briefly grief participants by changing `P_CL`, but even costlier to run due to the TWAP period.
+- If `P_CL` is about to be updated (i.e. oracle latency), traders will, at best, receive an output that is dampened by the `CL_BUFFER` rate. This essentially provides the same defense as fee reclamation, but taken in advance at a fixed rate.
+- If `P_DEX_TWAP` or `P_DEX_SPOT` is used, a synth trader's execution price could be negatively impacted by a price manipulation attack across multiple blocks on Uniswap. However, such attacks only grief the synth trader, not the debt pool, and come at large risk for the griefer due to the need to hold a position across multiple blocks and a lack of atomic execution (i.e. no Flashbots). This scenario would also be similar to a griefer risking capital in one or more CEXes to briefly grief participants by changing `P_CL`.
 - On-chain prices usually follow CEX, so a trader could “frontrun the on-chain market” at the expense of the debt pool in periods of clear market directionality. However, it could be argued that this also applies with fee reclamation, only that it requires more careful timing.
 
 The final concern was backtested with front-running strategies over a few periods of clear market directionality, showing that traders were likely to obtain positive results--at the expense of the debt pool--in such conditions if no price dampeners were included. Adding exchange fees into the model effectively hindered most strategies from taking profit, although it was observed that the necessary rates would be different between BTC and ETH, which prompted for per-synth configuration of the `CL_BUFFER` and exchange fee rates.
@@ -81,42 +118,47 @@ Finally, as further backstops to decrease the risk associated with this new exch
 
 ### Technical Specification
 
-Add the following interfaces and storage variables:
+First, refactor `Exchanger`, `ExchangerWithVirtualSynth`, and `ExchangeRates` into their shared base versions and L1-variants.
 
-- `Exchanger.exchangeAtomically()` and `Synthetix.exchangeAtomically()`
-- `ExchangeRates.effectiveAtomicValueAndRates()`
-- `Exchanger.lastAtomicVolume` (`struct { uint64 time, uint192 volume }`), `SystemSettings.atomicMaxVolumePerBlock` (`uint256`), and related setter `SystemSettings.setAtomicMaxVolumePerBlock()`, configurable by SCCPs
+Then, add the following interfaces and storage variables:
+
+- `ExchangerWithFeeReclamationAlternatives.exchangeAtomically()` and `Synthetix.exchangeAtomically()`
+- `ExchangeRatesWithDexPricing.effectiveAtomicValueAndRates()` and related setters to manage the `IDexPriceAggregator` to use
+- `ExchangerWithFeeReclamationAlternatives.lastAtomicVolume` (`struct { uint64 time, uint192 volume }`), `SystemSettings.atomicMaxVolumePerBlock` (`uint256`), and related setter `SystemSettings.setAtomicMaxVolumePerBlock()`, configurable by SCCPs
 - `SystemSettings.atomicTwapWindow` (`uint256`) and related setter `SystemSettings.setAtomicTwapWindow()`, configurable by SCCPs
 - `SystemSettings.atomicEquivalentForDexPricing` (`mapping (bytes32 => address)`) and related setter `SystemSettings.setAtomicEquivalentForDexPricing()`, configurable by SCCPs
 - `SystemSettings.atomicExchangeFeeRate` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicExchangeFeeRate()`, configurable by SCCPs
 - `SystemSettings.atomicPriceBuffer` (`mapping (bytes32 => uint256)`) and related setter `SystemSettings.setAtomicPriceBuffer()`, configurable by SCCPs
 
-In detail, `Exchanger.exchangeAtomically()` will:
+In detail, `ExchangerWithFeeReclamationAlternatives.exchangeAtomically()` will:
 
 1. Use the `onlySynthetixorSynth` modifier and other user-input related sanity checks
+1. Ensure the source and destination synths are not deemed too volatile
 1. Settle any previous fee reclamation exchanges on the source synth
-1. Select the execution price between `P_CLBUF` and `P_DEX` via `ExchangeRates.effectiveAtomicValueAndRates()`
+1. Select the execution price between `P_CLBUF` and `P_DEX` via `ExchangeRatesWithDexPricing.effectiveAtomicValueAndRates()`
 1. Sanity check the current exchange's Chainlink rates against the internal circuit breaker ([SIP-65](https://sips.synthetix.io/sips/sip-65)) as well as the obtained atomic rate against the current Chainlink rate
 1. Ensure both the source synth and destination synth can be atomically exchanged and that one of them is sUSD
-1. Update the volume counter, `Exchanger.lastAtomicVolume`, for the current exchange’s sUSD value and check that the per-block volume limit for atomic exchanges is not exceeded
+1. Update the volume counter, `ExchangerWithFeeReclamationAlternatives.lastAtomicVolume`, for the current exchange’s sUSD value and ensure the per-block volume limit for atomic exchanges is not exceeded
 1. Execute the exchange by burning source synth, issuing destination synth, and collecting fees. Crucially, this step issues destination synths directly to the account executing the exchange and does not create new virtual synths, bypassing fee reclamation. Fees collected will be derived from the amount of destination synths issued at this step.
 1. If required, remit the fee with any required conversions back to sUSD (priced via internal Chainlink rate) using either the default fee rate or atomic fee rate.
 1. Update internal bookkeeping with the new exchange and debt snapshot (priced via internal Chainlink rate), and emit related events
 1. Process trading rewards
 
-When diffed against the current `Exchanger.exchange()`, only steps 3 through 8 should present meaningful differences in `Exchanger.exchangeAtomically()`’s implementation.
+Note that internal system updates arising from the exchange, e.g. updating the debt cache or circuit breaker, will continue to use the current Chainlink rate rather than the selected execution price in 4.
 
-Note that internal system updates arising from the exchange, e.g. updating the debt cache or circuit breaker, will continue to use the current Chainlink rate rather than the selected execution price in 3.
-
-`ExchangeRates.effectiveAtomicValueAndRates()` selects the execution price by:
+`ExchangeRatesWithDexPricing.effectiveAtomicValueAndRates()` selects the execution price by:
 
 1. Applying `CL_BUFFER` to `P_CL` to obtain `P_CLBUF`
-1. Querying the [`UniswapV3CrossPoolOracle` contract (`0xeAAFD7547B781C60c71F0854a7dA2c1FF23a7dd0`)](https://etherscan.io/address/0xeaafd7547b781c60c71f0854a7da2c1ff23a7dd0) to obtain `P_DEX`
+1. Querying the `IDexPriceAggregator` contract (i.e. [`DexPriceAggregatorUniswapV3` (`0x`)](https://etherscan.io/address/0x#readContract)) to obtain `P_DEX`
 1. Outputting whichever of `P_CLBUF` and `P_DEX` provides the minimum output
 
-For step 2, note that due to the low liquidity of synths on Uniswap, queries to `UniswapV3CrossPoolOracle` require synths to be mapped to an equivalent non-synth version with high liquidity instead. This can be configured via SCCPs by calling `SystemSettings.setAtomicEquivalentForDexPricing()`.
+For step 2, note that due to the low liquidity of synths on DEXes, queries to `IDexPriceAggregator` use an equivalent non-synth version with high liquidity instead. This mapping can be configured via SCCPs by calling `SystemSettings.setAtomicEquivalentForDexPricing()`.
 
-In the event `UniswapV3CrossPoolOracle` needs to be replaced, for example to use a more complicated oracle that aggregates multiple DEXes, the owner of `ExchangeRates` will have the ability to do so.
+### Additional considerations
+
+It is worth noting that the debt cache may be adversely impacted by this SIP due to synths being priced differently (lower) than their internal, Chainlink-based price during atomic exchanges. Over time, it is likely extended usage of atomic exchanges will produce a skew in the debt cache opposite the direction of the majority of atomic exchanges.
+
+However, as of writing this SIP, it is expected that the current debt cache mechanism will be replaced by an off-chain snapshotting mechanism in the near future.
 
 ### Test Cases
 
@@ -164,7 +206,7 @@ Relevant only for atomic exchanges:
 
 - Per-block volume limit, specified in sUSD
 - TWAP time window, specified in number of seconds
-- Synth equivalents for TWAP price look ups, specified in token addresses
+- Synth equivalents for DEX-basd price queries, specified in token addresses
 - Synths allowed, specified with a synth having a mapped equivalent (above)
 - Fee override for atomic exchanges, specified in bps and per-synth
 - Price buffer against Chainlink, specified in bps and per-synth
@@ -184,7 +226,9 @@ Initially, this SIP proposes the following system configuration:
 
 SIP-120 was initially proposed with Keep3r's TWAP oracles, whose liveliness and correctness relied on an external network of incentivized actors to provide rates of whitelisted assets from Uniswap V2 and Sushiswap liquidity pools.
 
-However, near the end of this SIP's initial development, Uniswap V3 was revealed and, important to this SIP, included expanded oracle functionality that allowed one to retrieve TWAP rates directly from a Uniswap V3 pool. This was a critical improvement that allows the Synthetix system to both save gas and minimize external dependencies by not relying on an external network of actors to maintain a TWAP oracle.
+However, near the end of this SIP's initial development, Uniswap V3 was announced and, important to this SIP, included expanded oracle functionality that simplified the retrieval of TWAP rates by allowing other contracts to directly retrieve TWAP rates from a Uniswap V3 pool. Upgrading to this new version allowed the Synthetix system to both save gas and minimize external dependencies.
+
+A simplified proof-of-concept of this earlier version of the exchange mechanism can be found in [this `SynthetixAMM` contract](https://etherscan.io/address/0x70d8cdb1f0b684286335857514b9b63c8df2090d#code) which sourced DEX-based prices from (now defunct) Keep3r TWAP oracles.
 
 ## Copyright
 

--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -38,12 +38,12 @@ To facilitate atomic exchanges, the `Synthetix` and `Exchanger` contracts will e
 1. Not having a fee reclamation window and therefore not minting any virtual synths
 1. Restrictions on source and destination synths, configurable by SCCPs
 
-Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the execution price for atomic exchanges is selected between the prices given by Chainlink oracles and Uniswap V3 pools. Two distinct prices are considered, `P_CLBUF` and `P_TWAP`, with the selected execution price being the one that outputs the minimum amount of destination synths:
+Unlike `Exchanger.exchange()`, which relies solely on Chainlink oracles, the execution price for atomic exchanges is selected between the prices given by Chainlink oracles and Uniswap V3 pools. Two distinct prices are considered, `P_CLBUF` and `P_DEX`, with the selected execution price being the one that outputs the minimum amount of destination synths:
 
 - `P_CLBUF`: current Chainlink price, with a buffer of _N_ bps applied against the trading direction (specified per-synth)
-- `P_TWAP`: current Uniswap V3 TWAP price, over a window of _N_ seconds
+- `P_DEX`: current Uniswap V3 TWAP price, over a window of _N_ seconds
 
-`P_CLBUF` can be calculated internally within the current Synthetix system and `P_TWAP` will be provided externally via [`UniswapV3CrossPoolOracle` (`0x0F1f5A87f99f0918e6C81F16E59F3518698221Ff`)](https://etherscan.io/address/0x0f1f5a87f99f0918e6c81f16e59f3518698221ff#readContract).
+`P_CLBUF` can be calculated internally within the current Synthetix system and `P_DEX` will be provided externally via [`UniswapV3CrossPoolOracle` (`0x0F1f5A87f99f0918e6C81F16E59F3518698221Ff`)](https://etherscan.io/address/0x0f1f5a87f99f0918e6c81f16e59f3518698221ff#readContract).
 
 Finally, several new configuration settings are proposed:
 
@@ -59,10 +59,10 @@ A simplified proof-of-concept of this exchange mechanism can be found at [this `
 
 The most important considerations are with the price selection method. Ideally, the chosen method will strike a balance between preventing both flashloan style price attacks and frontrunning oracle latency attacks while enabling low-slippage execution of atomic synth exchanges for high-value, cross-asset swaps across multiple equivalent-asset AMM pools (e.g. Curve).
 
-The prices of `P_CLBUF` and `P_TWAP` have their own strengths and weaknesses:
+The prices of `P_CLBUF` and `P_DEX` have their own strengths and weaknesses:
 
 - `P_CLBUF`: `P_CL`, the current Chainlink price, is the official “internal” price used for all other exchanges and system debt calculations. However, its update latency is easily gamed via technical frontrunning in today’s circumstances. `P_CLBUF` provides a buffer of _N_ bps (`CL_BUFFER`) from `P_CL` to provide a safety net from the deviation threshold for Chainlink oracle updates. Note that `CL_BUFFER` is configurable per-synth and `P_CLBUF` is calculated using the larger `CL_BUFFER` of the source and destination synth.
-- `P_TWAP`: Uniswap V3 TWAPs are designed to only update based on the state at the beginning of the block, preventing flashloan style attacks and making longer-term manipulation costly to the attacker. However, by their construction, TWAPs always lag behind spot.
+- `P_DEX`: Uniswap V3 TWAPs are designed to only update based on the state at the beginning of the block, preventing flashloan style attacks and making longer-term manipulation costly to the attacker. However, by their construction, TWAPs always lag behind spot.
 
 By selecting the worst price between these two at any given time, the hope is that a “good enough but not exploitable” price can be obtained for the vast majority of situations. In the remainder, there may be periods of high volatility where one price dramatically lags behind, whereby traders will likely forgo atomic execution to obtain a better price through the fee reclamation route.
 
@@ -70,7 +70,7 @@ To show that the price selection method of choosing the price that gives the min
 
 - If any price provides better output than `P_CL`, a trader can immediately arbitrage back through a fee reclamation exchange
 - If `P_CL` is about to be updated, traders will, at best, receive an output that is dampened by the `CL_BUFFER` rate. This essentially provides the same defense as fee reclamation, but taken in advance at a fixed rate.
-- If `P_TWAP` is used, a synth trader's execution price could be negatively impacted by a price manipulation attack across multiple blocks on Uniswap. However, such attacks only grief the synth trader, not the debt pool, and come at large risk for the griefer due to the need to hold a position across multiple blocks and a lack of atomic execution (i.e. no Flashbots). This scenario would also be similar to a griefer risking capital in one or more CEXes to briefly grief participants by changing `P_CL`, but even costlier to run due to the TWAP period.
+- If `P_DEX` is used, a synth trader's execution price could be negatively impacted by a price manipulation attack across multiple blocks on Uniswap. However, such attacks only grief the synth trader, not the debt pool, and come at large risk for the griefer due to the need to hold a position across multiple blocks and a lack of atomic execution (i.e. no Flashbots). This scenario would also be similar to a griefer risking capital in one or more CEXes to briefly grief participants by changing `P_CL`, but even costlier to run due to the TWAP period.
 - On-chain prices usually follow CEX, so a trader could “frontrun the on-chain market” at the expense of the debt pool in periods of clear market directionality. However, it could be argued that this also applies with fee reclamation, only that it requires more careful timing.
 
 The final concern was backtested with front-running strategies over a few periods of clear market directionality, showing that traders were likely to obtain positive results--at the expense of the debt pool--in such conditions if no price dampeners were included. Adding exchange fees into the model effectively hindered most strategies from taking profit, although it was observed that the necessary rates would be different between BTC and ETH, which prompted for per-synth configuration of the `CL_BUFFER` and exchange fee rates.
@@ -95,7 +95,7 @@ In detail, `Exchanger.exchangeAtomically()` will:
 
 1. Use the `onlySynthetixorSynth` modifier and other user-input related sanity checks
 1. Settle any previous fee reclamation exchanges on the source synth
-1. Select the execution price between `P_CLBUF` and `P_TWAP` via `ExchangeRates.effectiveAtomicValueAndRates()`
+1. Select the execution price between `P_CLBUF` and `P_DEX` via `ExchangeRates.effectiveAtomicValueAndRates()`
 1. Sanity check the current exchange's Chainlink rates against the internal circuit breaker ([SIP-65](https://sips.synthetix.io/sips/sip-65)) as well as the obtained atomic rate against the current Chainlink rate
 1. Ensure both the source synth and destination synth can be atomically exchanged and that one of them is sUSD
 1. Update the volume counter, `Exchanger.lastAtomicVolume`, for the current exchange’s sUSD value and check that the per-block volume limit for atomic exchanges is not exceeded
@@ -111,8 +111,8 @@ Note that internal system updates arising from the exchange, e.g. updating the d
 `ExchangeRates.effectiveAtomicValueAndRates()` selects the execution price by:
 
 1. Applying `CL_BUFFER` to `P_CL` to obtain `P_CLBUF`
-1. Querying the [`UniswapV3CrossPoolOracle` contract (`0xeAAFD7547B781C60c71F0854a7dA2c1FF23a7dd0`)](https://etherscan.io/address/0xeaafd7547b781c60c71f0854a7da2c1ff23a7dd0) to obtain `P_TWAP`
-1. Outputting whichever of `P_CLBUF` and `P_TWAP` provides the minimum output
+1. Querying the [`UniswapV3CrossPoolOracle` contract (`0xeAAFD7547B781C60c71F0854a7dA2c1FF23a7dd0`)](https://etherscan.io/address/0xeaafd7547b781c60c71f0854a7da2c1ff23a7dd0) to obtain `P_DEX`
+1. Outputting whichever of `P_CLBUF` and `P_DEX` provides the minimum output
 
 For step 2, note that due to the low liquidity of synths on Uniswap, queries to `UniswapV3CrossPoolOracle` require synths to be mapped to an equivalent non-synth version with high liquidity instead. This can be configured via SCCPs by calling `SystemSettings.setAtomicEquivalentForDexPricing()`.
 
@@ -130,33 +130,33 @@ The cases below assume no trading fees or rebates are applied. Other configurati
 
 On a sUSD -> sETH trade of 1000 sUSD (prices reported in sUSD:sETH):
 
-- Given `P_TWAP` of 0.01, `P_CL` of 0.011, and `CL_BUFFER` of 50bps
-  - Choose 0.01 (`P_TWAP`) to output 10 sETH
-- Given `P_TWAP` of 0.01, `P_CL` of 0.0099, and `CL_BUFFER` of 50bps
+- Given `P_DEX` of 0.01, `P_CL` of 0.011, and `CL_BUFFER` of 50bps
+  - Choose 0.01 (`P_DEX`) to output 10 sETH
+- Given `P_DEX` of 0.01, `P_CL` of 0.0099, and `CL_BUFFER` of 50bps
   - Choose 0.0098505 (`P_CLBUF`) to output 9.8505 sETH
-- Given `P_TWAP` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 50bps
+- Given `P_DEX` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 50bps
   - Choose 0.00995 (`P_CLBUF`) to output 9.95 sETH
-- Given `P_TWAP` of 0.0099, `P_CL` of 0.01, and `CL_BUFFER` of 200bps
+- Given `P_DEX` of 0.0099, `P_CL` of 0.01, and `CL_BUFFER` of 200bps
   - Choose 0.0098 (`P_CLBUF`) to output 9.8 sETH
-- Given `P_TWAP` of 0.0099, `P_CL` of 0.01, and `CL_BUFFER` of 0bps
-  - Choose 0.0099 (`P_TWAP`) to output 9.9 sETH
-- Given `P_TWAP` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 0bps
-  - Choose 0.01 (`P_TWAP`/`P_CLBUF`) to output 10 sETH
+- Given `P_DEX` of 0.0099, `P_CL` of 0.01, and `CL_BUFFER` of 0bps
+  - Choose 0.0099 (`P_DEX`) to output 9.9 sETH
+- Given `P_DEX` of 0.01, `P_CL` of 0.01, and `CL_BUFFER` of 0bps
+  - Choose 0.01 (`P_DEX` or `P_CLBUF`) to output 10 sETH
 
 Conversely, on a sETH -> sUSD trade of 10 sETH (prices reported in sETH:sUSD):
 
-- Given `P_TWAP` of 100, `P_CL` of 110, and `CL_BUFFER` of 50bps:
-  - Choose 100 (`P_TWAP`) to output 1000 sUSD
-- Given `P_TWAP` of 100, `P_CL` of 99, and `CL_BUFFER` of 50bps
+- Given `P_DEX` of 100, `P_CL` of 110, and `CL_BUFFER` of 50bps:
+  - Choose 100 (`P_DEX`) to output 1000 sUSD
+- Given `P_DEX` of 100, `P_CL` of 99, and `CL_BUFFER` of 50bps
   - Choose 98.505 (`P_CLBUF`) to output 985.05 sUSD
-- Given `P_TWAP` of 100, `P_CL` of 100, and `CL_BUFFER` of 50bps
+- Given `P_DEX` of 100, `P_CL` of 100, and `CL_BUFFER` of 50bps
   - Choose 99.5 (`P_CLBUF`) to output 995 sUSD
-- Given `P_TWAP` of 99, `P_CL` of 100, and `CL_BUFFER` of 200bps
+- Given `P_DEX` of 99, `P_CL` of 100, and `CL_BUFFER` of 200bps
   - Choose 98 (`P_CLBUF`) to output 980 sUSD
-- Given `P_TWAP` of 99, `P_CL` of 100, and `CL_BUFFER` of 0bps
-  - Choose 99 (`P_TWAP`) to output 990 sUSD
-- Given `P_TWAP` of 100, `P_CL` of 100, and `CL_BUFFER` of 0bps
-  - Choose 100 (`P_TWAP`/`P_CLBUF`) to output 1000 sUSD
+- Given `P_DEX` of 99, `P_CL` of 100, and `CL_BUFFER` of 0bps
+  - Choose 99 (`P_DEX`) to output 990 sUSD
+- Given `P_DEX` of 100, `P_CL` of 100, and `CL_BUFFER` of 0bps
+  - Choose 100 (`P_DEX` or `P_CLBUF`) to output 1000 sUSD
 
 ### Configurable Values (Via SCCP)
 


### PR DESCRIPTION
Updates SIP-120 based on the latest implementation in https://github.com/Synthetixio/synthetix/pull/1127.

Easiest to review commits separately:

- 263fb98: Primary meat of the update with rewordings, re-organizations, and re-conceptualizations.
	- In particular, emphasizes this SIP does three things:
	  1. Refactors `Exchanger` and `ExchangeRates` into shared/L1-specific implementations
	  2. Introduces `exchangeAtomically()`, and
	  3. Introduces `IDexPriceAggregator` concept for querying DEX-based prices of synths
- 9b11f73: Adds details about the volatility circuit breaker
- 902a614: Renames the entire SIP to "Atomic Exchange Function", since the concept of a TWAP is more embedded in the DEX-based pricing mechanism than the overall functionality intended by the SIP
- 86f5c12, 1bbc96f, 83631ae: Cosmetic renamings of concepts (or typo fixes) to align with the current implementation
