### PR TITLE
Updates SIP-120 and SIP-169 for SC_Review_Pending and SIP-134 to Implemented

### DIFF
--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -1,7 +1,7 @@
 ---
 sip: 120
 title: TWAP Exchange Function
-status: Approved
+status: SC_Review_Pending
 author: Kain Warwick (@kaiynne), Andre Cronje (@andrecronje), Justin Moses (@justinjmoses), Brett Sun (@sohkai)
 discussions-to: https://research.synthetix.io/t/sip-120-keep3r-twap-exchange-function/364
 

--- a/content/sips/sip-134.md
+++ b/content/sips/sip-134.md
@@ -1,7 +1,7 @@
 ---
 sip: 134
 title: Minimal Proxies for Binary Options
-status: Rejected
+status: Implemented
 author: Danijel (@dgornjakovic),Justin Moses (@justinjmoses), Brett Sun (@sohkai), Anton Jurisevic (@zyzek)
 discussions-to: https://research.synthetix.io/t/sip-134-minimal-proxies-for-bos/386
 

--- a/content/sips/sip-169.md
+++ b/content/sips/sip-169.md
@@ -1,7 +1,7 @@
 ---
 sip: 169
 title: Deprecate low volume L1 Synths
-status: Feasibility
+status: SC_Review_Pending
 author: Jordan Momtazi (@hjmomtazi)
 discussions-to: https://research.synthetix.io
 


### PR DESCRIPTION
This PR:

- Updates SIP-120 TWAP Exchange Function to SC_Review_Pending
- Updates SIP-169 Deprecate low volume L1 Synths to SC_ReviewPending
