### PR TITLE
SIP-120: add production UniswapV3 oracle

### DIFF
--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -78,7 +78,7 @@ function assetToAsset(
 
 The external oracle contract implementing `IDexPriceAggregator` can source prices from any DEX and use any internal measure to aggregate multiple pricing methods. A complex example of an `IDexPriceAggregator` oracle contract would source prices from Uniswap V3 and Sushiswap, and aggregate their spot and TWAP prices together via a liquidity-weighted mean.
 
-Initially, this SIP proposes to use an `IDexPriceAggregator` that sources prices solely from Uniswap V3, returning the worst price between the "spot" and TWAP. This initial oracle has been deployed to [`0x` (`DexPriceAggregatorUniswapV3`)](https://etherscan.io/address/0x#readContract).
+Initially, this SIP proposes to use an `IDexPriceAggregator` that sources prices solely from Uniswap V3, returning the worst price between the "spot" and TWAP. This initial oracle has been deployed to [`0x925fc225dD238A4637E4aaD343332Ea580a43bb8` (`DexPriceAggregatorUniswapV3`)](https://etherscan.io/address/0x925fc225dD238A4637E4aaD343332Ea580a43bb8#readContract).
 
 #### `SystemSettings`
 
@@ -155,7 +155,7 @@ Note that internal system updates arising from the exchange, e.g. updating the d
 `ExchangeRatesWithDexPricing.effectiveAtomicValueAndRates()` selects the execution price by:
 
 1. Applying `CL_BUFFER` to `P_CL` to obtain `P_CLBUF`
-1. Querying the `IDexPriceAggregator` contract (i.e. [`DexPriceAggregatorUniswapV3` (`0x`)](https://etherscan.io/address/0x#readContract)) to obtain `P_DEX`
+1. Querying the `IDexPriceAggregator` contract (i.e. [`DexPriceAggregatorUniswapV3` (`0x925fc225dD238A4637E4aaD343332Ea580a43bb8`)](https://etherscan.io/address/0x925fc225dD238A4637E4aaD343332Ea580a43bb8#readContract)) to obtain `P_DEX`
 1. Outputting whichever of `P_CLBUF` and `P_DEX` provides the minimum output
 
 For step 2, note that due to the low liquidity of synths on DEXes, queries to `IDexPriceAggregator` use an equivalent non-synth version with high liquidity instead. This mapping can be configured via SCCPs by calling `SystemSettings.setAtomicEquivalentForDexPricing()`.

--- a/content/sips/sip-120.md
+++ b/content/sips/sip-120.md
@@ -78,7 +78,7 @@ function assetToAsset(
 
 The external oracle contract implementing `IDexPriceAggregator` can source prices from any DEX and use any internal measure to aggregate multiple pricing methods. A complex example of an `IDexPriceAggregator` oracle contract would source prices from Uniswap V3 and Sushiswap, and aggregate their spot and TWAP prices together via a liquidity-weighted mean.
 
-Initially, this SIP proposes to use an `IDexPriceAggregator` that sources prices solely from Uniswap V3, returning the worst price between the "spot" and TWAP. This initial oracle has been deployed to [`0x925fc225dD238A4637E4aaD343332Ea580a43bb8` (`DexPriceAggregatorUniswapV3`)](https://etherscan.io/address/0x925fc225dD238A4637E4aaD343332Ea580a43bb8#readContract).
+Initially, this SIP proposes to use an `IDexPriceAggregator` that sources prices solely from Uniswap V3, returning the worst price between the "spot" and TWAP. This initial oracle has been deployed to [`0x074Fe031AD93e6a2f6037EB1fAa0BDc424DCe79d` (`DexPriceAggregatorUniswapV3`)](https://etherscan.io/address/0x074Fe031AD93e6a2f6037EB1fAa0BDc424DCe79d#readContract).
 
 #### `SystemSettings`
 
@@ -155,7 +155,7 @@ Note that internal system updates arising from the exchange, e.g. updating the d
 `ExchangeRatesWithDexPricing.effectiveAtomicValueAndRates()` selects the execution price by:
 
 1. Applying `CL_BUFFER` to `P_CL` to obtain `P_CLBUF`
-1. Querying the `IDexPriceAggregator` contract (i.e. [`DexPriceAggregatorUniswapV3` (`0x925fc225dD238A4637E4aaD343332Ea580a43bb8`)](https://etherscan.io/address/0x925fc225dD238A4637E4aaD343332Ea580a43bb8#readContract)) to obtain `P_DEX`
+1. Querying the `IDexPriceAggregator` contract (i.e. [`DexPriceAggregatorUniswapV3` (`0x074Fe031AD93e6a2f6037EB1fAa0BDc424DCe79d`)](https://etherscan.io/address/0x074Fe031AD93e6a2f6037EB1fAa0BDc424DCe79d#readContract)) to obtain `P_DEX`
 1. Outputting whichever of `P_CLBUF` and `P_DEX` provides the minimum output
 
 For step 2, note that due to the low liquidity of synths on DEXes, queries to `IDexPriceAggregator` use an equivalent non-synth version with high liquidity instead. This mapping can be configured via SCCPs by calling `SystemSettings.setAtomicEquivalentForDexPricing()`.


### PR DESCRIPTION
Adds the intended UniswapV3 oracle to initially use for SIP-120.