### PR TITLE
Add Token Distribution Requirement

### DIFF
--- a/content/sips/sip-179.md
+++ b/content/sips/sip-179.md
@@ -24,6 +24,8 @@ Kwenta is an iteration of synthetix.exchange, a Synth trading exchange made by t
 
 If this SIP passes a number of other SIPs will then be proposed to formalise the governance processes for an independent Kwenta project.
 
+To ensure Synthetix benefits from this transition, the Kwenta protocol will commit 35% of the initial supply to be distributed to Synthetix stakers and early synthetix.exchange/Kwenta users. The Sparten Council will not recognize the formation of Kwenta as legitimate unless this is done.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Add a note in the specification that requires Kwenta to commit 35% of its initial supply to Synthetix stakers and synth traders. 
