### PR TITLE
Minor updates to SIP-174 spec

### DIFF
--- a/content/sips/sip-174.md
+++ b/content/sips/sip-174.md
@@ -58,21 +58,23 @@ By connecting the `SynthRedeemer` contract to `Issuer.removeSynth()`, we can ato
 
 ```solidity
 interface ISynthRedeemer {
-    // Rate of redemption - 0 for none
-    function redemptions(IERC20) view returns (uint);
+
+    function redemptions(address token) external view returns (uint redeemRate);
 
     // sUSD balance of deprecated token holder
-    function balanceOf(IERC20, address) view returns (uint);
+    function balanceOf(IERC20 token, address account) external view returns (uint balanceOfInsUSD);
 
     // Full sUSD supply of token
-    function totalSupply(IERC20 token) view returns (uint);
+    function totalSupply(IERC20 tokens) external view returns (uint totalSupplyInsUSD);
 
     function redeem(IERC20 token) external;
+
+    function redeemAll(IERC20[] calldata tokens) external;
 
     function redeemPartial(IERC20 token, uint amountOfSynth) external;
 
     // Restricted to Issuer
-    function deprecate(IERC20 synthProxy) external;
+    function deprecate(IERC20 token, uint rateToRedeem) external;
 }
 ```
 

--- a/content/sips/sip-174.md
+++ b/content/sips/sip-174.md
@@ -58,7 +58,7 @@ By connecting the `SynthRedeemer` contract to `Issuer.removeSynth()`, we can ato
 
 ```solidity
 interface ISynthRedeemer {
-
+    // Rate of redemption - 0 for none
     function redemptions(address token) external view returns (uint redeemRate);
 
     // sUSD balance of deprecated token holder
@@ -75,6 +75,11 @@ interface ISynthRedeemer {
 
     // Restricted to Issuer
     function deprecate(IERC20 token, uint rateToRedeem) external;
+
+    // Events
+    event SynthRedeemed(address synth, address account, uint amountOfSynth, uint amountInsUSD);
+
+    event SynthDeprecated(address synth, uint rateToRedeem, uint totalSynthSupply, uint supplyInsUSD);
 }
 ```
 


### PR DESCRIPTION
Minor updates to spec to match implementation. 

- `redemptions` is a mapping function and takes an `address`
- `redeemAll` helper function added
- `deprecate` has an additional `rateToRedeem` argument.