### PR TITLE
Update sip-135.md

### DIFF
--- a/content/sips/sip-135.md
+++ b/content/sips/sip-135.md
@@ -91,7 +91,7 @@ To summarize how this will work:
 - Charge the effective exchange fee for sUSD -> sETH / sBTC   + a service fee that is configurable.
 - Burn the sUSD collateral and reduces the borrowed sETH / sBTC units by the amount repaid (less exchange fees).
 
-The effective exchange fee for exchanging `sUSD` to the borrowed debt (sETH, sBTC) will be charged for swapping the `sUSD` collateral to repay the loan. A base % fee to be charged and payable to the feepool for the function to repay using sUSD collateral instead of acquiring the borrowed synth to repay the borrowed synth. Default base fee would be 15 bps (0.15%) on top of the exchange fee and as mentioned above the base fee is a configurable value.
+The effective exchange fee for exchanging `sUSD` to the borrowed debt (sETH, sBTC) will be charged for swapping the `sUSD` collateral to repay the loan. A base % fee to be charged and payable to the feepool for the function to repay using sUSD collateral instead of acquiring the borrowed synth to repay the borrowed synth. Default base fee would be 0 bps (0.0%) on top of the exchange fee and as mentioned above the base fee is a configurable value.
 
 ### Removing the interaction delay if a short position is in liquidation state
 
@@ -117,7 +117,7 @@ Unit tests included with implementation.
 
 ### Configurable Values (Via SCCP)
 
-- Collapsible short loans base fee (Default 15 bps)
+- Collapsible short loans base fee (Default 0 bps)
 
 - Adding shorting against other synth assets beyond just sETH and sBTC. Will be proposed via an SCCP.
 


### PR DESCRIPTION
Updated collapse service fee to default `0` fee per the conversation in #l2-shorts Discord channel.