### PR TITLE
add council-dilution-to-ovm sip-191

### DIFF
--- a/content/sips/sip-191.md
+++ b/content/sips/sip-191.md
@@ -1,0 +1,80 @@
+---
+sip: 191
+title: Moving Council Dilution to Optimism
+status: Draft
+author: Andy T CF (@andytcf)
+implementor: Andy T CF (@andytcf)
+release: TBD
+discussions-to: 'https://research.synthetix.io'
+created: 2021-11-18T00:00:00.000Z
+type: Meta-Governance
+---
+
+## Simple Summary
+
+<!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->
+
+CouncilDilution.sol (introduced in [SIP-104](https://sips.synthetix.io/sips/sip-104/) which is used to store the hashes of SCCPs/SIPs created on snapshot is currently deployed on L1, it has become too expensive and slow for proposal creators to carry out their role in governance.
+
+Moving this process to OVM and updating the apps to support OVM governance will alleviate the issue of governance artifact cost and speed.
+
+## Abstract
+
+<!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the SIP is implemented, not *why* it should be done or *how* it will be done. If the SIP proposes deploying a new contract, write, "We propose to deploy a new contract that will do x".-->
+
+The CouncilDilution.sol contract will be deployed on optimism and integrated within the Staking dApp. This integration will shift all governance features to be compatible with L2/OVM.
+
+For proposal creators, they will create a snapshot proposal in the same way but this hash is then stored in the OVM instance of the contract.
+
+For the end users, they will be prompted to connect to the OVM chain id in order to view and interact with governance.
+
+## Motivation
+
+<!--This is the problem statement. This is the *why* of the SIP. It should clearly explain *why* the current state of the protocol is inadequate.  It is critical that you explain *why* the change is needed, if the SIP proposes changing how something is calculated, you must address *why* the current calculation is inaccurate or wrong. This is not the place to describe how the SIP will address the issue!-->
+
+Due to the recent gas prices, proposal creators have been experienced significant cost when executing the transaction that saves proposal hashes to the L1 instance of CouncilDilution.sol.
+
+This cost has caused proposal creators to either
+
+1. pay a large amount of ETH for fast confirmation
+2. setting a low gas price and letting the tx sit in pending
+
+Both scenarios have caused additional deterrents in the Spartan Council voting process leading to longer wait times for proposals to be voted on.
+
+## Specification
+
+<!--The specification should describe the syntax and semantics of any new feature, there are five sections
+1. Overview
+2. Rationale
+3. Technical Specification
+4. Test Cases
+5. Configurable Values
+-->
+
+### Overview
+
+<!--This is a high-level overview of *how* the SIP will solve the problem. The overview should clearly describe how the new feature will be implemented-->
+
+This SIP will deploy the CouncilDilution.sol contract on OVM which will significantly reduce the cost and time for SIP/SCCP proposals to be created and stored to be voted on.
+
+### Rationale
+
+<!--This is where you explain the reasoning behind how you propose to solve the problem. Why did you propose to implement the change in this way, what were the considerations and trade-offs? The rationale fleshes out what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+This SIP proposes OVM as the layer 2 solution as it is most aligned with the rest of the Synthetix Roadmap as the system is transitioning to OVM.
+
+Synthetix is also whitelisted for OVM deployment making this possible.
+
+### Technical Specification
+
+If this SIP is approved, the current L1 contract [here](https://etherscan.io/address/0xFf4e21298E5DCE1398d6fc9857098Eae3cAF1e72) will be deprecated and deployed to OVM using the Synthetix deployer (whitelisted)
+
+### Configurable Values (Via SCCP)
+
+<!--Please list all values configurable via SCCP under this implementation.-->
+
+N/A
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This PR introduces SIP-191

CouncilDilution.sol (introduced in [SIP-104](https://sips.synthetix.io/sips/sip-104/) which is used to store the hashes of SCCPs/SIPs created on snapshot is currently deployed on L1, it has become too expensive and slow for proposal creators to carry out their role in governance.

Moving this process to OVM and updating the apps to support OVM governance will alleviate the issue of governance artifact cost and speed.
