### PR TITLE
SIP-199: Update to make sSOL shortable 

### DIFF
--- a/content/sips/sip-199.md
+++ b/content/sips/sip-199.md
@@ -6,7 +6,7 @@ status: Approved
 type: Governance
 author: Cody Adam (@cadam17)
 implementor: TBD
-release: TBD 
+release: TBD
 created: 2022-01-13T00:00:00.000Z
 proposal: >-
   https://snapshot.org/#/snxgov.eth/proposal/QmTyChipBC1Xx8uUMhuqsk8N5hCbbv5yipKWQB7vBKoUfW
@@ -18,7 +18,7 @@ Add SOL Synth on Optimism.
 
 ### Overview
 
-This SIP will add a Synth for the SOL token on Optimism.
+This SIP will add a Synth for the SOL token on Optimism and make it shortable.
 
 ### Motivation
 
@@ -26,15 +26,17 @@ SOL is one of the most liquid markets in all of crypto and listing this synth on
 
 ### Rationale
 
-Additional crypto Synths will add further utility to the Synthetix protocol. SOL was chosen for nomination with consensus from the Lyra Council and was deemed to have sufficient liquidity. 
+Additional crypto Synths will add further utility to the Synthetix protocol. SOL was chosen for nomination with consensus from the Lyra Council and was deemed to have sufficient liquidity.
 
 DYDX weekly volume: $142m  
 CEX listings: Binance, FTX, Coinbase, Huobi  
-Market Cap: $43b  
+Market Cap: $43b
 
 ### Specification
 
-This Synth will be implemented in the same way as other long crypto Synths on Optimism.
+This Synth will be implemented in the same way as other crypto Synths on Optimism (by performing a call to `ExchangeRates.addAggregator`).
+
+It will also be made shortable via the `CollateralShort` contract by calling `CollateralManager.addShortableSynths`.
 
 ### Copyright
 

--- a/content/sips/sip-200.md
+++ b/content/sips/sip-200.md
@@ -4,8 +4,6 @@ title: Fix FeePool Rewards Distribution
 network: Ethereum & Optimism
 status: Implemented
 type: Governance
-proposal: >-
-  https://snapshot.org/#/snxgov.eth/proposal/QmYCFBmqVZgsdW1T9yFTn4NTXY591pQyyYPrAQuiwNXXuw
 author: Mark E. Barrasso (@barrasso), Noah Litvin (@noahlitvin)
 implementor: Mark E. Barrasso (@barrasso)
 release: Peacock

--- a/content/sips/sip-200.md
+++ b/content/sips/sip-200.md
@@ -2,8 +2,10 @@
 sip: 200
 title: Fix FeePool Rewards Distribution
 network: Ethereum & Optimism
-status: Draft
+status: Implemented
 type: Governance
+proposal: >-
+  https://snapshot.org/#/snxgov.eth/proposal/QmYCFBmqVZgsdW1T9yFTn4NTXY591pQyyYPrAQuiwNXXuw
 author: Mark E. Barrasso (@barrasso), Noah Litvin (@noahlitvin)
 implementor: Mark E. Barrasso (@barrasso)
 release: Peacock


### PR DESCRIPTION
Lyra has requested to update the SIP to make sure `sSOL` is also added as a `shortableSynth`.  

> "In order to test delta hedging, it would need to be available to short." -Lyra