### PR TITLE
Update SIP-165 with new plan for the oracle

### DIFF
--- a/content/sips/sip-165.md
+++ b/content/sips/sip-165.md
@@ -107,9 +107,9 @@ async function debtSynthesisOracle() {
 
 #### Protocol Updates
 
-- **Debt Cache Deprecation**: The debt cache will no longer be used going forward. The related keeper no longer needs to be maintained. The contract can be left in place, at minimum, to provide access to the `totalNonSnxBackedDebt` and `currentDebt` functions for the oracle.
+- **Debt Cache Deprecation**: The debt cache will no longer be used going forward. The related keeper no longer needs to be maintained. The contract can be left in place, at minimum, to provide access to the `currentDebt` function for the oracle.
 
-- **Synth Issuance**: The issuer will now rely on the `totalDebtIssued` and `totalDebtShares` reported from the oracle rather than the equivalent values provided by the debt ledger and the debt cache.
+- **Synth Issuance**: The issuer will now rely on the `totalDebtIssued` and `totalDebtShares` reported from the oracles rather than the equivalent values provided by the debt ledger and the debt cache.
 
 - **SNX Rewards**: SNX rewards will be provided to users proportionally on the networks that they are using to stake. This means that, in a given fee period, a staker will receive the same SNX rewards regardless how their staked funds are distributed across chains (as the percentage of debt shares that they own is agnostic to this distribution). 
 

--- a/content/sips/sip-165.md
+++ b/content/sips/sip-165.md
@@ -66,10 +66,10 @@ const { BigNumber } = require("ethers");
 const { synthetix } = require('@synthetixio/contracts-interface');
 
 async function debtSynthesisOracle() {
-    const NETWORK_IDS = [1, 10]
+    const NETWORK_IDS = [1, 10];
 
-    let totalDebtIssued = BigNumber.from(0)
-    let totalDebtShares = BigNumber.from(0)
+    let totalDebtIssued = BigNumber.from(0);
+    let totalDebtShares = BigNumber.from(0);
 
     for (networkId of NETWORK_IDS) {
         const snxjs = synthetix({ networkId });
@@ -78,7 +78,7 @@ async function debtSynthesisOracle() {
         totalDebtShares = totalDebtShares.add(await snxjs.contracts.SynthetixDebtShare.totalSupply());
     }
 
-    return totalDebtIssued.mul(10e27).div(totalDebtShares)
+    return totalDebtIssued.mul(BigNumber.from(10).pow(27)).div(totalDebtShares);
 }
 ```
 
@@ -89,9 +89,9 @@ const { BigNumber } = require("ethers");
 const { synthetix } = require('@synthetixio/contracts-interface');
 
 async function debtSynthesisOracle() {
-    const NETWORK_IDS = [1, 10]
+    const NETWORK_IDS = [1, 10];
 
-    let totalDebtIssued = BigNumber.from(0)
+    let totalDebtIssued = BigNumber.from(0);
 
     for (networkId of NETWORK_IDS) {
         const snxjs = synthetix({ networkId });
@@ -99,7 +99,7 @@ async function debtSynthesisOracle() {
         totalDebtIssued = totalDebtIssued.add(await snxjs.contracts.DebtCache.currentDebt());
     }
 
-    return totalDebtIssued
+    return totalDebtIssued;
 }
 ```
 

--- a/content/sips/sip-165.md
+++ b/content/sips/sip-165.md
@@ -68,21 +68,21 @@ const { synthetix } = require('@synthetixio/contracts-interface');
 async function debtSynthesisOracle() {
     const NETWORK_IDS = [1, 10]
 
-    let totalSnxBackedDebt = BigNumber.from(0)
+    let totalDebtIssued = BigNumber.from(0)
     let totalDebtShares = BigNumber.from(0)
 
     for (networkId of NETWORK_IDS) {
         const snxjs = synthetix({ networkId });
 
-        totalSnxBackedDebt = totalSnxBackedDebt.add(await snxjs.contracts.DebtCache.currentDebt());
+        totalDebtIssued = totalDebtIssued.add(await snxjs.contracts.DebtCache.currentDebt());
         totalDebtShares = totalDebtShares.add(await snxjs.contracts.SynthetixDebtShare.totalSupply());
     }
 
-    return totalSnxBackedDebt.div(totalDebtShares)
+    return totalDebtIssued.div(totalDebtShares)
 }
 ```
 
-Another oracle should be deployed to report the total debt shares across all chains. This is useful for computing rewards, as we can determine a given staker's proportion of the total debt shares. We can also use this derive the total current debt by relying on the ratio value reported by the oracle specified above.
+Another oracle should be deployed to report the total debt issued across all chains. We can also use this derive the total debt shares by relying on the ratio value reported by the oracle specified above.
 
 ```javascript
 const { BigNumber } = require("ethers");
@@ -91,15 +91,15 @@ const { synthetix } = require('@synthetixio/contracts-interface');
 async function debtSynthesisOracle() {
     const NETWORK_IDS = [1, 10]
 
-    let totalDebtShares = BigNumber.from(0)
+    let totalDebtIssued = BigNumber.from(0)
 
     for (networkId of NETWORK_IDS) {
         const snxjs = synthetix({ networkId });
         
-        totalDebtShares = totalDebtShares.add(await snxjs.contracts.SynthetixDebtShare.totalSupply());
+        totalDebtIssued = totalDebtIssued.add(await snxjs.contracts.DebtCache.currentDebt());
     }
 
-    return totalDebtShares
+    return totalDebtIssued
 }
 ```
 
@@ -109,7 +109,7 @@ async function debtSynthesisOracle() {
 
 - **Debt Cache Deprecation**: The debt cache will no longer be used going forward. The related keeper no longer needs to be maintained. The contract can be left in place, at minimum, to provide access to the `totalNonSnxBackedDebt` and `currentDebt` functions for the oracle.
 
-- **Synth Issuance**: The issuer will now rely on the `totalSnxBackedDebt` and `totalDebtShares` reported from the oracle rather than the equivalent values provided by the debt ledger and the debt cache.
+- **Synth Issuance**: The issuer will now rely on the `totalDebtIssued` and `totalDebtShares` reported from the oracle rather than the equivalent values provided by the debt ledger and the debt cache.
 
 - **SNX Rewards**: SNX rewards will be provided to users proportionally on the networks that they are using to stake. This means that, in a given fee period, a staker will receive the same SNX rewards regardless how their staked funds are distributed across chains (as the percentage of debt shares that they own is agnostic to this distribution). 
 
@@ -119,7 +119,7 @@ async function debtSynthesisOracle() {
 
 - **Loans**: The interest rates charged on loans are determined by examining an aggregate skew in the system. This may be difficult to compute accurately across two chains. It should be verified that the behavior of the loans contracts only examine the skew on their own chain, not involving the full cross-chain debt, if it isn’t feasible to properly account for it.
 
-Also note that is possible for the `totalSnxBackedDebt` to become negative if the value of synths backed by SNX tokens is less than the amount backed by wrappers and shorts. This risk already exists and is mitigated by the growth of incentives for individual SNX stakers as the debt pool becomes smaller.
+Also note that is possible for the `totalDebtIssued` to become negative if the value of synths backed by SNX tokens is less than the amount backed by wrappers and shorts. This risk already exists and is mitigated by the growth of incentives for individual SNX stakers as the debt pool becomes smaller.
 
 ### Test Cases
 

--- a/content/sips/sip-165.md
+++ b/content/sips/sip-165.md
@@ -78,7 +78,7 @@ async function debtSynthesisOracle() {
         totalDebtShares = totalDebtShares.add(await snxjs.contracts.SynthetixDebtShare.totalSupply());
     }
 
-    return totalDebtIssued.div(totalDebtShares)
+    return totalDebtIssued.mul(10e27).div(totalDebtShares)
 }
 ```
 
@@ -103,7 +103,7 @@ async function debtSynthesisOracle() {
 }
 ```
 
-*A previous iteration of this SIP involved a single oracle which packed each value into the upper and lower bits of a uint256. The proposal has been updated due the Chainlink oracle infrastructure rounding the resulting value in some cases.*
+*A previous iteration of this SIP involved a single oracle which packed `totalDebtIssued` and `totalDebtShares` into the upper and lower bits of a uint256. The proposal has been updated due the Chainlink oracle infrastructure rounding the resulting value in some cases.*
 
 #### Protocol Updates
 

--- a/content/sips/sip-165.md
+++ b/content/sips/sip-165.md
@@ -42,7 +42,7 @@ Merging the debt pools is necessary to provide maximum liquidity across the prot
 
 ### Overview
 
-The Chainlink oracle must monitor the debt composition across all chains, and simultaneously push updates for the aggregated amount of debt and total debt shares to all of those chains.
+The Chainlink oracles must monitor the debt composition across all chains and push relevant values to all of those chains.
 
 The issuer should rely on the global values provided by this oracle—rather than chain-specific values—for the total debt shares (which is replacing the debt ledger system) and value of the total debt backed by the debt pool. Consequently, the debt cache is no longer needed to track the value of the total debt and so the debt pool oracles that would replace the debt cache (specified in [SIP-156](https://sips.synthetix.io/sips/sip-156)) does not need to be implemented.
 
@@ -56,11 +56,11 @@ Although it would be possible to transmit debt updates between chains directly, 
 
 Implementation of this SIP involves a new Chainlink oracle and assorted updates to the protocol.
 
-#### Debt Synthesis Oracle
+#### Debt Synthesis Oracles
 
-This SIP relies on a single oracle that tracks the total issued synths and the total debt shares across all chains and then updates these values across all chains. It is important that the oracle reports these values together to minimize front-running opportunities. Review the **Test Cases** for more considerations regarding front-running.
+This SIP relies on an oracle that provides the ratio between the total issued synths and the total debt shares across all chains and then updates these values across all chains. It is important that one oracle reports the ratio, rather than the individual values seperately, to minimize front-running opportunities. Review the **Test Cases** for more considerations regarding front-running.
 
-This JavaScript code demonstrates the value that the oracle should update on each chain, ideally every block:
+This JavaScript code demonstrates the value that the oracle should update on each chain:
 ```javascript
 const { BigNumber } = require("ethers");
 const { synthetix } = require('@synthetixio/contracts-interface');
@@ -74,15 +74,36 @@ async function debtSynthesisOracle() {
     for (networkId of NETWORK_IDS) {
         const snxjs = synthetix({ networkId });
 
-        totalSnxBackedDebt = totalSnxBackedDebt.add(await snxjs.contracts.DebtCache.currentDebt()).sub(await snxjs.contracts.DebtCache.totalNonSnxBackedDebt())
+        totalSnxBackedDebt = totalSnxBackedDebt.add(await snxjs.contracts.DebtCache.currentDebt());
         totalDebtShares = totalDebtShares.add(await snxjs.contracts.SynthetixDebtShare.totalSupply());
     }
 
-    const totalSnxBackedDebtPart = totalSnxBackedDebt.toHexString().slice(2).padStart(32, '0');
-    const totalDebtSharesPart = totalDebtShares.toHexString().slice(2).padStart(32, '0');
-    return "0x" + totalSnxBackedDebtPart + totalDebtSharesPart
+    return totalSnxBackedDebt.div(totalDebtShares)
 }
 ```
+
+Another oracle should be deployed to report the total debt shares across all chains. This is useful for computing rewards, as we can determine a given staker's proportion of the total debt shares. We can also use this derive the total current debt by relying on the ratio value reported by the oracle specified above.
+
+```javascript
+const { BigNumber } = require("ethers");
+const { synthetix } = require('@synthetixio/contracts-interface');
+
+async function debtSynthesisOracle() {
+    const NETWORK_IDS = [1, 10]
+
+    let totalDebtShares = BigNumber.from(0)
+
+    for (networkId of NETWORK_IDS) {
+        const snxjs = synthetix({ networkId });
+        
+        totalDebtShares = totalDebtShares.add(await snxjs.contracts.SynthetixDebtShare.totalSupply());
+    }
+
+    return totalDebtShares
+}
+```
+
+*A previous iteration of this SIP involved a single oracle which packed each value into the upper and lower bits of a uint256. The proposal has been updated due the Chainlink oracle infrastructure rounding the resulting value in some cases.*
 
 #### Protocol Updates
 


### PR DESCRIPTION
A previous iteration of this SIP involved a single oracle which packed `totalDebtIssued` and `totalDebtShares` into the upper and lower bits of a uint256. The proposal has been updated due the Chainlink oracle infrastructure rounding the resulting value in some cases.