### PR TITLE
229 update to simpler oracle implementation and rename

### DIFF
--- a/content/sips/sip-229.md
+++ b/content/sips/sip-229.md
@@ -38,9 +38,11 @@ This will also lead to easier migration of debt from L1 to L2, forced or not.
 
 #### Bridge
 
-New methods `depositSynth(bytes32 name, address destination, uint amount)` and `withdrawSynth(bytes32 name, address destination, uint amount)` will be added to `BaseSynthetixBridge`. Upon call to `depositSynth`, synth will be burnt from the user, and
-a cross-chain message sent to the destination chain counterpart to call `withdrawSynth`. When `withdrawSynth` is called, the usual checks are done to verify the
+New methods `initializeSynthTransfer(address destination, uint amount)` and `finalizeSynthTransfer(address destination, uint amount)` will be added to `BaseSynthetixBridge`. Upon call to `initializeSynthTransfer`, sUSD will be burnt from the user, and
+a cross-chain message sent to the destination chain counterpart to call `finalizeSynthTransfer`. When `finalizeSynthTransfer` is called, the usual checks are done to verify the
 message origin, and then the appropriate synths are minted for the user.
+
+In order to allow chainlink to track debt which is in transit between chains, the running tallies, `synthTransferSent` and `synthTransferReceived` will be recorded. By comparing the difference between these values on opposite chains, it is possible to see how much synth is in transit.
 
 The actual mint and burn will be done through `Issuer` to reduce
 the upgrade complexity.
@@ -51,18 +53,17 @@ The `optimism.github.io` repository will need to be updated to include the `sUSD
 
 #### Chainlink
 
-Chainlink will need to track a new source for the issued synths and debt ratio oracle, the synths in transit.
+Chainlink will need to track 2 new sources per chain for the issued synths and debt ratio oracle, the synths in transit.
 
-In an atomic call, the oracle should retrieve the values for `currentDebt` and the last `n` events for `SynthSent`, and the last `n` events for `SynthReceived`, where `n` is the largest expected number of synth transfers in flight.
-
-After retrieving data from all networks, the synths in transit can be calculated:
+In pseudocode, the new equation for the `issued synths` value within the debt oracles is:
 
 ```
-let synthsNotReceivedEvents = synthSentEvents.filter(e => synthReceivedEvents.find(e.id))
-let synthsInTransit = sum(synthsNotReceivedEvents, 'amount');
+sum(DebtCache.currentDebt() + SynthetixBridge.synthTransferReceived() - SynthetixBridge.synthTransferSent()) for all chains
 ```
 
-`synthsInTransit` should be added to the final total for issued synths.
+Note that the contract calls should be atomic or locked to a specific block on-chain.
+
+Also note, on Optimism, the `SynthetixBridge` contract is called `SynthetixBridgeToBase`. On mainnet, the contract is called `SynthetixBridgeToOptimism`. The appropriate contract should be queried for its address from the `AddressResolver` as we are doing with existing addresses.
 
 Chainlink will be responsible for implementing the code for this additional requirement.
 

--- a/content/sips/sip-229.md
+++ b/content/sips/sip-229.md
@@ -12,7 +12,7 @@ created: 2022/04/04
 
 <!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->
 
-Enable the transfer of sUSD for deposit and withdrawal through Optimism Bridge
+Enable the transfer of synths for deposit and withdrawal through Optimism Bridge. Initially, only sUSD will be enabled for transfer.
 
 ## Abstract
 
@@ -38,18 +38,18 @@ This will also lead to easier migration of debt from L1 to L2, forced or not.
 
 #### Bridge
 
-New methods `initializeSynthTransfer(address destination, uint amount)` and `finalizeSynthTransfer(address destination, uint amount)` will be added to `BaseSynthetixBridge`. Upon call to `initializeSynthTransfer`, sUSD will be burnt from the user, and
+New methods `initializeSynthTransfer(bytes32 currencyKey, address destination, uint amount)` and `finalizeSynthTransfer(bytes32 currencyKey, address destination, uint amount)` will be added to `BaseSynthetixBridge`. Upon call to `initializeSynthTransfer`, the specified synth will be burnt from the user, and
 a cross-chain message sent to the destination chain counterpart to call `finalizeSynthTransfer`. When `finalizeSynthTransfer` is called, the usual checks are done to verify the
 message origin, and then the appropriate synths are minted for the user.
 
-In order to allow chainlink to track debt which is in transit between chains, the running tallies, `synthTransferSent` and `synthTransferReceived` will be recorded. By comparing the difference between these values on opposite chains, it is possible to see how much synth is in transit.
+In order to allow chainlink to track debt which is in transit between chains, the running mapped tallies, `synthTransferSent` and `synthTransferReceived` will be recorded. By comparing the difference between these values on opposite chains, it is possible to see how much synth is in transit.
 
 The actual mint and burn will be done through `Issuer` to reduce
 the upgrade complexity.
 
 #### Optimism
 
-The `optimism.github.io` repository will need to be updated to include the `sUSD` synth information and contract address so that its information appears on Optimism Gateway.
+The `optimism.github.io` repository will need to be updated to include the `sUSD` synth information and contract address so that its information appears on Optimism Gateway. If any other synths are approved by the council in the future, they will need to be added using the same process.
 
 #### Chainlink
 
@@ -69,7 +69,7 @@ Chainlink will be responsible for implementing the code for this additional requ
 
 ### Configurable Values (Via SCCP)
 
-No new values.
+`crossChainSynthTransferEnabled(bytes32 currencyKey)`: specifies whether or not synth is allowed to be initiated for transfer to other layer. 0 = disabled, all other values = enabled
 
 ## Copyright
 


### PR DESCRIPTION
* there is an easier way for chainlink to report the amount of issued synths without looking at events. This info has been updated on the SIP.
* changed the name of the proposed functions to match the actual functions implemented now

When opening a pull request to submit a new SIP, please use the suggested template: https://github.com/Synthetixio/SIPs/blob/master/sip-X.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing Draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
