### PR TITLE
229 fix error in equation for issued synths

### DIFF
--- a/content/sips/sip-229.md
+++ b/content/sips/sip-229.md
@@ -2,7 +2,9 @@
 sip: 229
 title: Optimism Bridge for Synths
 network:  Ethereum & Optimism 
-status: Draft
+status: Approved
+proposal: >-
+  https://snapshot.org/#/snxgov.eth/proposal/QmQnro52vRMSKmayn7Tfi4bG3eRd3L134GZi7Dt4d4cfbm
 type: Governance
 author: Daniel Beal (@dbeal-eth)
 created: 2022/04/04
@@ -58,7 +60,7 @@ Chainlink will need to track 2 new sources per chain for the issued synths and d
 In pseudocode, the new equation for the `issued synths` value within the debt oracles is:
 
 ```
-sum(DebtCache.currentDebt() + SynthetixBridge.synthTransferReceived() - SynthetixBridge.synthTransferSent()) for all chains
+sum(DebtCache.currentDebt() + SynthetixBridge.synthTransferSent() - SynthetixBridge.synthTransferReceived()) for all chains
 ```
 
 Note that the contract calls should be atomic or locked to a specific block on-chain.


### PR DESCRIPTION
the equation provided for synthTransferSent/synthTransferReceived addition was inverse of what it should have been. When synths are in transit, we want to *add* additional debt, not subtract it

When opening a pull request to submit a new SIP, please use the suggested template: https://github.com/Synthetixio/SIPs/blob/master/sip-X.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing Draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
