### PR TITLE
Update README Contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Synthetix Improvement Proposals (SIPs) describe standards for the Synthetix plat
 
 # Contributing
 
-1.  Review [SIP-1](sips/sip-1.md).
+1.  Review [SIP-1](content/sips/sip-1.md).
 2.  Fork the repository by clicking "Fork" in the top right.
 3.  Add your SIP to your fork of the repository. There is a [template SIP here](sip-x.md).
 4.  Submit a Pull Request to Synthetix's [SIPs repository](https://github.com/synthetixio/SIPs).


### PR DESCRIPTION
README has a guide for contributing SIP's. It appears that when a subdirectory for SCCP's and SIP's was created, the link in the guide was not updated for it.

Steps:
Go to SIP repository and look at the readme
Click the Review SIP-1 link
Observe that it's currently broken
