### PR TITLE
Dark mode toggle

### DIFF
--- a/old.css
+++ b/old.css
@@ -34,6 +34,10 @@ body {
   min-height: 100vh;
   flex-direction: column;
 }
+body.dark {
+  color: #eee;
+  background-color: #020202;
+}
 
 h1,
 h2,
@@ -92,12 +96,21 @@ a {
   color: #2a7ae2;
   text-decoration: none;
 }
+.dark a  {
+  color: #2a7ae2;
+}
 a:visited {
+  color: #1756a9;
+}
+.dark a:visited {
   color: #1756a9;
 }
 a:hover {
   color: #111;
   text-decoration: underline;
+}
+.dark a:hover {
+  color: #eee;
 }
 .social-media-list a:hover {
   text-decoration: none;
@@ -114,6 +127,10 @@ blockquote {
   letter-spacing: -1px;
   font-style: italic;
 }
+.dark blockquote  {
+  color: #7d7d7d;
+  border-left: 4px solid #171717;
+}
 blockquote > :last-child {
   margin-bottom: 0;
 }
@@ -124,6 +141,11 @@ code {
   border: 1px solid #e8e8e8;
   border-radius: 3px;
   background-color: #eef;
+}
+.dark pre,
+.dark code {
+  border: 1px solid #171717;
+  background-color: #110;
 }
 
 code {
@@ -172,6 +194,9 @@ pre > code {
   padding-right: 5px;
   vertical-align: text-top;
 }
+.dark .svg-icon {
+  fill: #7d7d7d;
+}
 
 .social-media-list li + li {
   padding-top: 5px;
@@ -185,8 +210,15 @@ table {
   border-collapse: collapse;
   border: 1px solid #e8e8e8;
 }
+.dark table {
+  color: #c0c0c0;
+  border: 1px solid #171717;
+}
 table tr:nth-child(even) {
   background-color: #f7f7f7;
+}
+.dark table tr:nth-child(even) {
+  background-color: #080808;
 }
 table th,
 table td {
@@ -197,8 +229,16 @@ table th {
   border: 1px solid #dedede;
   border-bottom-color: #c9c9c9;
 }
+.dark table th {
+  background-color: #0f0f0f;
+  border: 1px solid #212121;
+  border-bottom-color: #363636;
+}
 table td {
   border: 1px solid #e8e8e8;
+}
+.dark table td {
+  border: 1px solid #171717;
 }
 
 /** Site header */
@@ -207,6 +247,10 @@ table td {
   border-bottom: 1px solid #e8e8e8;
   min-height: 55.95px;
   position: relative;
+}
+.dark .site-header {
+  border-top: 5px solid #bdbdbd;
+  border-bottom: 1px solid #171717;
 }
 
 .site-title {
@@ -220,6 +264,10 @@ table td {
 .site-title,
 .site-title:visited {
   color: #424242;
+}
+.dark .site-title,
+.dark .site-title:visited {
+  color: #bdbdbd;
 }
 
 .site-nav {
@@ -236,6 +284,9 @@ table td {
   color: #111;
   line-height: 1.5;
 }
+.dark .site-nav .page-link {
+  color: #eee;
+}
 .site-nav .page-link:not(:last-child) {
   margin-right: 20px;
 }
@@ -248,6 +299,10 @@ table td {
     border: 1px solid #e8e8e8;
     border-radius: 5px;
     text-align: right;
+  }
+  .dark .site-nav {
+    background-color: #020202;
+    border: 1px solid #171717;
   }
   .site-nav label[for='nav-trigger'] {
     display: block;
@@ -268,6 +323,9 @@ table td {
   }
   .site-nav .menu-icon > svg {
     fill: #424242;
+  }
+  .dark .site-nav .menu-icon > svg {
+    fill: #bdbdbd;
   }
   .site-nav input ~ .trigger {
     clear: both;
@@ -291,6 +349,9 @@ table td {
   border-top: 1px solid #e8e8e8;
   padding: 30px 0;
 }
+.dark .site-footer {
+  border-top: 1px solid #171717;
+}
 
 .footer-heading {
   font-size: 18px;
@@ -307,6 +368,9 @@ table td {
   font-size: 15px;
   color: #828282;
   margin-left: -15px;
+}
+.dark .footer-col-wrapper {
+  color: #7d7d7d;
 }
 
 .footer-col {
@@ -373,6 +437,9 @@ table td {
   font-size: 14px;
   color: #828282;
 }
+.dark .post-meta {
+  color: #7d7d7d;
+}
 
 .post-link {
   display: block;
@@ -426,8 +493,14 @@ table td {
 .highlight {
   background: #fff;
 }
+.dark .highlight {
+  background: #000;
+}
 .highlighter-rouge .highlight {
   background: #eef;
+}
+.dark .highlighter-rouge .highlight {
+  background: #110;
 }
 .highlight .c {
   color: #998;

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,47 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+function presetTheme() {
+  const dark = localStorage.getItem("theme") === "dark";
+
+  if (dark) {
+    document.body.classList.add("dark");
+  }
+}
+
+const themeScript = `(() => { ${presetTheme.toString()}; presetTheme() })()`;
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        <script dangerouslySetInnerHTML={{ __html: themeScript, }} />
+        {props.preBodyComponents}
+        <div
+          key={`body`}
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}

--- a/src/icons/DarkMode.tsx
+++ b/src/icons/DarkMode.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+function SvgDarkMode(
+  props: React.SVGProps<SVGSVGElement>,
+  svgRef?: React.Ref<SVGSVGElement>,
+) {
+  return (
+    <svg
+      width={16}
+      height={16}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      ref={svgRef}
+      {...props}
+    >
+      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+    </svg>
+  )
+}
+
+const ForwardRef = React.forwardRef(SvgDarkMode)
+export default ForwardRef

--- a/src/icons/LightMode.tsx
+++ b/src/icons/LightMode.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+
+function SvgLightMode(
+  props: React.SVGProps<SVGSVGElement>,
+  svgRef?: React.Ref<SVGSVGElement>,
+) {
+  return (
+    <svg
+      fillRule="evenodd"
+      clipRule="evenodd"
+      width={16}
+      height={16}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      ref={svgRef}
+      {...props}
+    >
+      <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" />
+    </svg>
+  )
+}
+
+const ForwardRef = React.forwardRef(SvgLightMode)
+export default ForwardRef

--- a/src/layout/Main.tsx
+++ b/src/layout/Main.tsx
@@ -1,9 +1,35 @@
 import React from 'react'
+import { useEffect } from 'react';
 
 import GithubIcon from '../icons/Github'
 import TwitterIcon from '../icons/Twitter'
+import LightModeIcon from '../icons/LightMode'
+import DarkModeIcon from '../icons/DarkMode'
+
+const toggleTheme = (e) => {
+  e.preventDefault();
+  const element = document.body;
+  document.getElementById("theme-toggle-dark-icon")?.classList.toggle("hidden");
+  document.getElementById("theme-toggle-light-icon")?.classList.toggle("hidden");
+  const result = element.classList.toggle("dark");
+  localStorage.setItem('theme', result ? 'dark' : 'light');
+}
+
+const initTheme = () => {
+  const element = document.body;
+  if(element.classList.contains('dark')) {
+    document.getElementById("theme-toggle-light-icon")?.classList.remove("hidden");
+  }
+  else {
+    document.getElementById("theme-toggle-dark-icon")?.classList.remove("hidden");
+  }
+}
 
 const Main: React.FC = ({ children }) => {
+  useEffect(() => {
+    initTheme();
+  }, []);
+
   return (
     <main>
       {/* matomo */}
@@ -62,7 +88,15 @@ const Main: React.FC = ({ children }) => {
           <div className="footer-col-wrapper">
             <div className="footer-col footer-col-1">
               <ul className="contact-list">
-                <li className="p-name">SIPs</li>
+                <li className="p-name">
+                  SIPs
+                </li>
+                <li className="p-name">
+                  <a href="#" className="page-link inline-block align-middle" onClick={toggleTheme}>
+                    <span id="theme-toggle-dark-icon" className="hidden"><DarkModeIcon className="svg-icon" /></span>
+                    <span id="theme-toggle-light-icon" className="hidden"><LightModeIcon className="svg-icon" /></span>
+                  </a>
+                </li>
               </ul>
             </div>
 


### PR DESCRIPTION
In an effort to not get blasted with white light I made a dark mode toggle, with a tiny toggle icon in the footer.

Impementation and functionality:
* All CSS classes that included color now also have a variant that alters the color if `.dark` is higher up in the hierarchy. The `.dark` class is added to `body` when dark mode is enabled.
* The theme is stored to `localStorage` when toggled.
* It uses `dangerouslySetInnerHTML` in `html.js` to get a flicker-free theme experience.
* I've manually reviewed some SIPs with this functionality, but not all.

Notes:
* I've added no `.dark` variant for `.highlight` classes, as I'm unsure when they are used.
* Some images/graphical elements that have black lines and transparent background may not display well in dark mode.