### PR TITLE
Proposed SIPs on accountability and governance protection

### DIFF
--- a/content/sips/SIP-draft_title_GovenorAccountability.md
+++ b/content/sips/SIP-draft_title_GovenorAccountability.md
@@ -1,0 +1,71 @@
+---
+sip: <to be assigned>
+title: Governance Accountability
+network: Ethereum & Optimism
+status: <Draft>
+type: Meta-Governance
+author:  Adam Cochran
+implementor:me 
+release:
+implementation-date:
+discussions-to: 
+proposal:
+created: 2023-04-25
+requires:
+---
+
+## Simple Summary
+
+This SIP will expand the Inactivity Threshold for Spartan Council to a greater degree of involvement than current standards to ensure activity.
+
+## Abstract
+
+SIP-274 established an inactivity threshold for Spartan Council that extended only to governance votes. It provides the Spartan Council and pDAO the right, but not the obligation to dismiss councillors if they've missed more than 5 votes within a single epoch.
+
+This abstract aims to increase the responsibility by extending that to:
+
+- Missing >3 SIP proposal calls within a single epoch, without a valid reason as judged by peers.
+- Missing >3 internal calls within a single epoch, without a valid reason as judged by peers.
+- Not having feedback or commentary on at least 5 SIPs within a single epoch, or 33% of SIPs if less than 10 total SIPs that epoch.
+- Not having a meaningful verbal contribution in at least 3 SIP calls during a single epoch.
+
+## Motivation
+
+Spartan Council is the highest office within our governance system, and in these previous cycles there has been a notable decline in councillor engagement, which is unfair to this community which provides councillors with a stipend for their work.
+
+These rules aim to increase the level of accountability that the Spartan Council faces, and provide prospective councillors with a more clear overview of the responsibilities of taking on this role. These rules do not aim to be a cureall but instead a first step in improving our accountability process.
+
+## Specification
+
+There is no specific technical specification for this SIP.
+
+Instead the only specification to note, is that similar to SIP-274 create the *right* but not the obligation for remaining members of the Spartan Council to start the dismissal process along with pDAO.
+
+In each case, there can be valid reasons for absences, or the decision that contributions and an intent to improve on missteps merit the councillor not being removed, this power rests therefore with a jury of their peers letting the remaining Spartan Council members who are not underreview weigh up the decision to dismiss.
+
+As with SIP-274, the dismal is a matter of metagovernance and requires an n-1 vote of eligible voters, excluding the Spartan Councillor under review, in order to pass.
+
+### Overview
+
+-pDAO will be given the authority to review candidates upon the start of a new epoch and withhold the governance NFT, or remove the governance NFT from any candidates who are councillors who were previously expelled by metagovernance vote.
+-A Spartan Council may at any time hold a metagovernance vote to expunge the record of a former expelled councillor if they are deemed to not be a threat by that council to the governance process.
+
+### Rationale
+
+With our current system pDAO stands as the last fail safe to ensure smooth transition of power, without a way to fairly enforce the decisions that a voted on Spartan Council has put in place in prior cycles, there would be no consistency and the protocol would be subject to governance attacks in cycles with high governance apathy.
+
+### Technical Specification
+
+No needed technical changes. 
+
+### Test Cases
+
+No needed technical changes. 
+
+### Configurable Values (Via SCCP)
+
+No needed technical changes. 
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/content/sips/sip-draft_title_pdaoProtectGov.md
+++ b/content/sips/sip-draft_title_pdaoProtectGov.md
@@ -1,0 +1,60 @@
+---
+sip: <to be assigned>
+title: pDAO authority to protect governance
+network: Ethereum & Optimism
+status: <Draft>
+type: Meta-Governance
+author:  Adam Cochran
+implementor:me 
+release:
+implementation-date:
+discussions-to: 
+proposal:
+created: 2023-04-25
+requires:
+---
+
+## Simple Summary
+
+This proposal gives pDAO the ability to not award a governance NFT, or to remove the governance NFT from a user who won a governance election if they have previously been removed from a council for inactivity or malice, including extending to their alt addresses.
+
+## Abstract
+
+The Synthetix voting system allows for individuals to run in the Spartan Council elections, and to vote for themselves, even in cases where the user has been previously expelled from a council. This includes the ability for a user to use new addresses or identities in order to run for council, leaving our governance process susceptible to governance attacks from motivated actors.
+
+The goal of this SIP is to give pDAO the authority to not award (or if already awarded to remove) the governance NFT from any actor who is either a previously expelled councillor or found to be the alt of a previously expelled councillor.
+
+## Motivation
+
+Previously Synthetix had not ever had expelled councillors, nor motivated individuals with enough voting authority to vote themselves unduely on to council. However, in the current climate of apathy around defi governance, and with the recent expulsion of William87/Polik/Pollik/Napgener/Sam/Samantha, and his statements on intending to run in the next election with mulitple alts, it is important that the Spartan Council gives the pDAO clear guidelines and authorities to ensure the peaceful transfer of power between epochs.
+
+## Specification
+
+There is no need for a technical specification here as this SIP simply makes clear that pDAO has the right to use their current technical means of removing a governance NFT if the candidate was previously expelled.
+
+It should however allow a Spartan Council, once duely in session, to hold a meta-governance vote to expunge a former expulsion and allow said candidate to run again should they be deemed to not be a risk and were merely inactive.
+
+### Overview
+
+-pDAO will be given the authority to review candidates upon the start of a new epoch and withhold the governance NFT, or remove the governance NFT from any candidates who are councillors who were previously expelled by metagovernance vote.
+-A Spartan Council may at any time hold a metagovernance vote to expunge the record of a former expelled councillor if they are deemed to not be a threat by that council to the governance process.
+
+### Rationale
+
+With our current system pDAO stands as the last fail safe to ensure smooth transition of power, without a way to fairly enforce the decisions that a voted on Spartan Council has put in place in prior cycles, there would be no consistency and the protocol would be subject to governance attacks in cycles with high governance apathy.
+
+### Technical Specification
+
+No needed technical changes. 
+
+### Test Cases
+
+No needed technical changes. 
+
+### Configurable Values (Via SCCP)
+
+No needed technical changes. 
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Below are two draft SIPs outlining proposed changes to:

- pDAO's ability to remove governance NFTs from the alts of previously expelled councilors given recent threats from former expelled councilor to disrupt governance process

- Expanding the accountability of the Spartan Council to ensure SC members are held accountable and properly engaged.