### PR TITLE
Remove snapshot header from STP template

### DIFF
--- a/stp-x.md
+++ b/stp-x.md
@@ -5,7 +5,6 @@ status: <Draft>
 author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
 implementation-date:
 discussions-to: <TC Discord Channel>
-proposal: <link to snapshot. Remove this line completely if the STP is in draft and there is no snapshot link yet>: https://snapshot.org/#/snxgov.eth/proposal/xxx 
 created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
 ---
 


### PR DESCRIPTION
Remove snapshot from header

When opening a pull request to submit a new SIP, please use the suggested template: https://github.com/Synthetixio/SIPs/blob/master/sip-X.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing Draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
