### PR TITLE
SIP-2058 (update): List Axelar Token (AXL) on Synthetix Perps for Base chain.

### DIFF
--- a/content/sips/sip-2058.md
+++ b/content/sips/sip-2058.md
@@ -1,11 +1,11 @@
 ---
 sip: 2058
-title: List AXL on Synthetix Perps
-network: Optimism
+title: List AXL on Synthetix Perps for Base
+network: Base
 status: Draft
 type: Governance
 author: npty (@npty)
-created: 2024-03-03
+created: 2024-03-26
 ---
 
 <!--You can leave these HTML comments in your merged SIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new SIPs. Note that an SIP number will be assigned by an editor. When opening a pull request to submit your SIP, please use an abbreviated title in the filename, `sip-draft_title_abbrev.md`. The title should be 44 characters or less.-->
@@ -14,13 +14,13 @@ created: 2024-03-03
 
 <!--"If you can't explain it simply, you don't understand it well enough." Simply describe the outcome the proposed changes intends to achieve. This should be non-technical and accessible to a casual community member.-->
 
-List Axelar Token (AXL) on Synthetix Perps.
+List Axelar Token (AXL) on Synthetix Perps for the Base chain.
 
 ## Abstract
 
 <!--A short (~200 word) description of the proposed change, the abstract should clearly describe the proposed change. This is what *will* be done if the SIP is implemented, not *why* it should be done or *how* it will be done. If the SIP proposes deploying a new contract, write, "we propose to deploy a new contract that will do x".-->
 
-This is a proposal to list Axelar Token (AXL) perpetual on Synthetix Perps.
+This is a proposal to list Axelar Token (AXL) perpetual on Synthetix Perps for the Base chain.
 
 ## Motivation
 
@@ -52,7 +52,7 @@ Axelar has partnered with leading DeFi applications such as dYdX and Lido. RWA i
 
 <!--The technical specification should outline the public API of the changes proposed. That is, changes to any of the interfaces Synthetix currently exposes or the creations of new ones.-->
 
-The perps market will require Pyth price feed oracle to be deployed on OP Mainnet.
+The perps market will require Pyth price feed oracle to be deployed on Base Mainnet.
 
 ### Test Cases
 


### PR DESCRIPTION
This PR updates SIP-2058 to propose listing on the Base chain instead of Optimism. The original proposal can be found here: https://github.com/Synthetixio/SIPs/pull/1865