### PR TITLE
Change from Base to Arbitrum target deployment

### DIFF
--- a/content/sccp/sccp-305.md
+++ b/content/sccp/sccp-305.md
@@ -1,7 +1,7 @@
 ---
 sccp: 305
 title: BetSwirl - Create Pool and register Market
-network: Base
+network: Arbitrum
 author: Romauld Hog (@RomualdH), Cavalier (@cavalier_eth)
 status: Draft
 type: Governance
@@ -13,20 +13,20 @@ created: 2023-09-01
 ## Simple Summary
 
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the SCCP.-->
-Create a BetSwirl Pool and register a BetSwirl Market, so that Betswirl can launch on Synthetix v3.
+Create a BetSwirl Pool and register a BetSwirl Market, so that BetSwirl can launch on Synthetix v3.
 
 ## Abstract
 
 <!--A short (~200 word) description of the variable change proposed.-->
 
-Create a new v3 Pool called “Betswirl”, controlled by Betswirl treasury, in line with [SIP-302](https://sips.synthetix.io/sips/sip-302/): 
+Create a new v3 Pool called “BetSwirl”, controlled by BetSwirl treasury, in line with [SIP-302](https://sips.synthetix.io/sips/sip-302/): 
 
-- *createPool(5,* [0x9f72820ee00d54330F9Ba31ff6006116D7ddFE67](https://etherscan.io/address/0x9f72820ee00d54330F9Ba31ff6006116D7ddFE67) *)*
-- *setPoolName(5, “Betswirl Pool”)*
+- *createPool(5,* [0xf14C79a7fA22c1f97C779F573c9bF39b6b43381c](https://arbiscan.io/address/0xf14C79a7fA22c1f97C779F573c9bF39b6b43381c)*)*
+- *setPoolName(5, “BetSwirl Pool”)*
 
-Register a new v3 Market called “Betswirl”
+Register a new v3 Market called “BetSwirl”
 
-- *registerMarket(*[addressOfNewBetswirlMarket]*)*
+- *registerMarket(*[addressOfNewBetSwirlMarket]*)*
 
 ## Motivation
 
@@ -34,7 +34,7 @@ Register a new v3 Market called “Betswirl”
 
 Synthetix v3 is ready to support third-party protocols willing to self-collateralize their Pools. BetSwirl, a decentralized GambleFi platform seeks to integrate with Synthetix v3 to tap into new liquidity, expand its user base, and consolidate fragmented collateral. Live for more than a year, BetSwirl has generated $32 million in wagered volume, $900k in annualized fees, and consumed 2.7k $LINK on Chainlink VRF. 
 
-The proposal seeks to launch a BetSwirl Market on Synthetix v3, and backed exclusively by a newly created BetSwirl Pool. Betswirl will deposit the initial SNX into the Betswirl Pool. BetSwirl is committed to demonstrating the performance of its Market against their Protocol Owned Liquidity in their v3 Pool, as well as offering Synthetix LPs the option to delegate to the BetSwirl Pool. Given that Market and Pool creation on v3 isn't currently permissionless, this proposal seeks Spartan Council's approval.
+The proposal seeks to launch a BetSwirl Market on Synthetix v3, and backed exclusively by a newly created BetSwirl Pool. BetSwirl will deposit the initial SNX into the BetSwirl Pool. BetSwirl is committed to demonstrating the performance of its Market against their Protocol Owned Liquidity in their v3 Pool, as well as offering Synthetix LPs the option to delegate to the BetSwirl Pool. Given that Market and Pool creation on v3 isn't currently permissionless, this proposal seeks Spartan Council's approval.
 
 By integrating with v3, BetSwirl seeks to become a part of the Synthetix ecosystem, without adding any risk to the Spartan Pool.
 


### PR DESCRIPTION
Base doesn't have Chainlink VRF deployed yet, we'd like to start on Arbitrum.