### PR TITLE
SIP for Synthetix to adopt PER on Base

### DIFF
--- a/content/sips/sip-391.md
+++ b/content/sips/sip-391.md
@@ -2,11 +2,9 @@
 sip: 391
 title: Liquidations on Synthetix using Pyth's Express Relay
 network: Base
-status: <Draft>
+status: Draft
 type: Governance
-author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): Yaser J (@)
-implementor: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@YaserJazouane)
-proposal: <snapshot.org proposal link> (*optional)
+author:  Yaser (@YaserJazouane)
 created: 2024-06-05
 requires: SIP-383
 ---

--- a/content/sips/sip-391.md
+++ b/content/sips/sip-391.md
@@ -1,0 +1,46 @@
+---
+sip: 391
+title: Liquidations on Synthetix using Pyth's Express Relay
+network: Base
+status: <Draft>
+type: Governance
+author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): Yaser J (@)
+implementor: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@YaserJazouane)
+proposal: <snapshot.org proposal link> (*optional)
+created: 2024-06-05
+requires: SIP-383
+---
+
+## Simple Summary
+
+Douro Labs proposes for Synthetix on Base to adopt Express Relay (testnet revealed here: https://forum.pyth.network/t/express-relay-prototype/569) to convert margin positions that are eligible to liquidation to USDC through the protocol’s network of Searchers:
+
+- The goal is to reduce slippage through competitive bidding
+- Applicable to both spontaneous and forced liquidations
+- Synthetix LPs receive USDC and improve their UX instead of receiving non-USDC collateral as currently the case
+
+## Abstract
+
+The proposed liquidation process can be broken down to the following:
+
+- when a user’s position becomes eligible for liquidation, the margin (when denominated in X, X ≠ USDC) is offered to Express Relay for conversion to USDC at the current Pyth price or at a discount (Synthetix protocol to decide)
+- searchers compete over the liquidation by bidding a premium denominated in USDC
+- the winning searcher with the highest premium amount pays the premium and amount of USDC, and receives the associated amount of X
+- the sum of the amount of USDC + premium is paid and distributed to LPs on Base, instead of distributing X, resulting in better UX
+
+## Motivation
+
+- Express Relay prevents opportunistic transaction ordering surrounding liquidations
+- Express Relay has searchers that can measure arbitrage opportunities on CEX’s and DEX’s that enables to measure the premium that can be paid on top current or discounted Pyth price, specific to the quantity of margin to be liquidated
+
+## Specification
+
+The adoption of PER is contingent on the support of multi collateral by Synthetix, proposed and adopted here: https://sips.synthetix.io/sips/sip-383/
+
+### Technical Specification
+
+Pending engineers input
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Douro Labs proposes for Synthetix on Base to adopt Express Relay (testnet revealed here: https://forum.pyth.network/t/express-relay-prototype/569) to convert margin positions that are eligible to liquidation to USDC through the protocol’s network of Searchers
