### PR TITLE
SIP-400 Fix for underflow error when offchain price timestamp is bigger than current block timestamp

### DIFF
--- a/content/sips/sip-400.md
+++ b/content/sips/sip-400.md
@@ -1,0 +1,42 @@
+---
+sip: 400
+network: Mainnet, Optimism, Base, Arbitrum
+title: Fix for underflow error when offchain price timestamp is bigger than current block timestamp
+status: Draft
+author: Noisekit
+created: 2024-07-29
+type: Governance
+---
+
+## Simple Summary
+
+Fix a bug in `StalenessCircuitBreakerNode` that results in an underflow error when the off-chain price update timestamp exceeds the current block timestamp.
+
+## Abstract
+
+Propose an update to the `StalenessCircuitBreakerNode` script to handle situations where the off-chain price update timestamp is in the "future" for the current block. Accompany the bug fix with corresponding tests.
+
+## Motivation
+
+Every chain mints blocks with a reasonable delay. If a fresh price update transaction retrieves a timestamp that is in the "future" relative to the current block, this results in an underflow error. Fixing this error will make the `StalenessCircuitBreakerNode` script more resilient and ensure its correct functioning under this particular condition.
+
+## Specification
+
+### Technical
+
+We propose to adjust the `StalenessCircuitBreakerNode` contract to cater to situations where the off-chain price update timestamp exceeds the current block timestamp.
+
+The proposed adjustment addresses the underflow error and ensures that the `StalenessCircuitBreakerNode` script does not fail due to this specific scenario.
+
+In addition to the bug fix, we suggest adding new tests to the test suite that cover this particular case. Doing so will help maintain the robustness of the existing test suite and catch any future recurrences of this problem.
+
+Incorrect implementation leading to arithmetic underflow 
+```js
+if (block.timestamp - priceNodeOutput.timestamp <= stalenessTolerance) {
+```
+to be fixed with 
+```js
+if (block.timestamp - stalenessTolerance <= priceNodeOutput.timestamp) {
+```
+
+This will ensure we do not get negative values when `priceNodeOutput.timestamp` is greater than `block.timestamp`


### PR DESCRIPTION
## Simple Summary

Fix a bug in `StalenessCircuitBreakerNode` that results in an underflow error when the off-chain price update timestamp exceeds the current block timestamp.

## Abstract

Propose an update to the `StalenessCircuitBreakerNode` script to handle situations where the off-chain price update timestamp is in the "future" for the current block. Accompany the bug fix with corresponding tests.

## Motivation

Every chain mints blocks with a reasonable delay. If a fresh price update transaction retrieves a timestamp that is in the "future" relative to the current block, this results in an underflow error. Fixing this error will make the `StalenessCircuitBreakerNode` script more resilient and ensure its correct functioning under this particular condition.

## Specification

### Technical

We propose to adjust the `StalenessCircuitBreakerNode` contract to cater to situations where the off-chain price update timestamp exceeds the current block timestamp.

The proposed adjustment addresses the underflow error and ensures that the `StalenessCircuitBreakerNode` script does not fail due to this specific scenario.

In addition to the bug fix, we suggest adding new tests to the test suite that cover this particular case. Doing so will help maintain the robustness of the existing test suite and catch any future recurrences of this problem.

Incorrect implementation leading to arithmetic underflow 
```js
if (block.timestamp - priceNodeOutput.timestamp <= stalenessTolerance) {
```
to be fixed with 
```js
if (block.timestamp - stalenessTolerance <= priceNodeOutput.timestamp) {
```

This will ensure we do not get negative values when `priceNodeOutput.timestamp` is greater than `block.timestamp`
