### PR TITLE
typo fix sccp-373.md

### DIFF
--- a/content/sccp/sccp-373.md
+++ b/content/sccp/sccp-373.md
@@ -20,7 +20,7 @@ This SCCP proposes to update the trading fee distribution split as per the below
 |    **V3 LPs**    |          40%         |       60%       |
 |  **Integrators** |          20%         |       20%       |
 
-It is important to mention that Treasury, signaled their intention to help supplement the v3 lp apy, by using part of their integrator fees in order to partially settle the v3 lp's debt. This would be performed at Treasury's descrition.
+It is important to mention that Treasury, signaled their intention to help supplement the v3 lp apy, by using part of their integrator fees in order to partially settle the v3 lp's debt. This would be performed at Treasury's description.
 
 # Motivation
 


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `sccp-373.md`**

## Description  
This pull request corrects a typo in the `sccp-373.md` document. The word "descrition" has been corrected to "description" to ensure proper spelling and clarity.

### Changes Made:
- **File Modified:** `sccp-373.md`
- **Summary of Changes:**  
  - Corrected the typo from "descrition" to "description" in the sentence regarding Treasury's actions.

## Checklist  
- [x] Fixed the typo in the document.
- [x] Verified that the sentence is now correctly spelled.

## Additional Notes  
This small change ensures the document's professionalism and clarity.

---

**Allow edits by maintainers:** [x]
