### PR TITLE
Fix typo Update sccp-2009.md

### DIFF
--- a/content/sccp/sccp-2009.md
+++ b/content/sccp/sccp-2009.md
@@ -21,7 +21,7 @@ These changes can only be enacted subsequent to the bedrock release.
 
 <!--A short (~200 word) description of the variable change proposed.-->
 
-- The `offchainDelayedOrderMinAge` represents the least amount of time that needs to elapse, since the order committment time, beore a delayed offchain order can be executed. 
+- The `offchainDelayedOrderMinAge` represents the least amount of time that needs to elapse, since the order commitment time, beore a delayed offchain order can be executed. 
 - The `offchainDelayedOrderMaxAge` represents the longest amount of time that can elapse, since the order committment time, during which a positon can be executed. 
 
 ## Motivation


### PR DESCRIPTION
It looks like you're correcting a typo in the sccp-2009.md file, specifically with the word "beore" (which should be "before") and "committment" (which should be "commitment").

Here is the corrected version:

Original: "The offchainDelayedOrderMinAge represents the least amount of time that needs to elapse, since the order committment time, beore a delayed offchain order can be executed."
Corrected: "The offchainDelayedOrderMinAge represents the least amount of time that needs to elapse, since the order commitment time, before a delayed offchain order can be executed."
This is a helpful and important fix as it corrects both typos and enhances the clarity of the documentation.